### PR TITLE
Fix active profile thin directory reads

### DIFF
--- a/commands/history.sh
+++ b/commands/history.sh
@@ -50,12 +50,101 @@ _snapshot_live_for_diff() {
       continue
     fi
     if [[ -e "$f" ]]; then
-      cp -RH "$f" "$dst/$base" || return 1
+      cp -RL "$f" "$dst/$base" || return 1
     fi
   done
   # Special: copy ~/.claude.json
   if [[ -e "$HOME/.claude.json" ]]; then
-    cp -RH "$HOME/.claude.json" "$dst/.claude.json" || return 1
+    cp -RL "$HOME/.claude.json" "$dst/.claude.json" || return 1
+  fi
+}
+
+_clear_diff_worktree() {
+  local repo="$1"
+  local f
+  for f in "$repo"/* "$repo"/.*; do
+    local base
+    base="$(basename "$f")"
+    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" ]]; then
+      continue
+    fi
+    rm -rf "$f"
+  done
+}
+
+_prepare_diff_baseline_repo() {
+  local profile_dir="$1" repo="$2"
+  local ignore_content=""
+
+  if [[ -f "$profile_dir/.gitignore" ]]; then
+    ignore_content="$(cat "$profile_dir/.gitignore")"
+  fi
+
+  if git -C "$profile_dir" rev-parse --verify HEAD >/dev/null 2>&1; then
+    git -C "$profile_dir" archive HEAD | tar -x -f - -C "$repo" || return 1
+    if [[ -z "$ignore_content" && -f "$repo/.gitignore" ]]; then
+      ignore_content="$(cat "$repo/.gitignore")"
+    fi
+  fi
+
+  git -C "$repo" init -q || return 1
+  if [[ -n "$ignore_content" ]]; then
+    printf '%s\n' "$ignore_content" >> "$repo/.git/info/exclude"
+  fi
+  rm -f "$repo/.gitignore"
+  git -C "$repo" add -A -- . || return 1
+  git -C "$repo" \
+    -c user.name=claude-profile \
+    -c user.email=claude-profile@example.invalid \
+    commit -q -m "Diff baseline" --allow-empty || return 1
+}
+
+_diff_git_status() {
+  local repo="$1"
+  git -C "$repo" status --porcelain --untracked-files=all -- . ':!.gitignore' \
+    | sed 's/^/  /'
+}
+
+_diff_active_unsaved() {
+  local profile_dir="$1"
+  local tmp repo changes
+  tmp="$(mktemp -d)" || return 1
+  trap "rm -rf '$tmp'" EXIT
+
+  repo="$tmp/repo"
+  mkdir -p "$repo"
+  if ! _prepare_diff_baseline_repo "$profile_dir" "$repo"; then
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  _clear_diff_worktree "$repo"
+  if ! _snapshot_live_for_diff "$repo"; then
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  changes="$(_diff_git_status "$repo")" || {
+    rm -rf "$tmp"
+    return 1
+  }
+  rm -rf "$tmp"
+
+  if [[ -n "$changes" ]]; then
+    echo "$changes"
+  else
+    echo -e "  ${DIM}(no changes)${NC}"
+  fi
+}
+
+_diff_profile_unsaved() {
+  local profile_dir="$1"
+  local changes
+  changes="$(_diff_git_status "$profile_dir")" || return 1
+  if [[ -n "$changes" ]]; then
+    echo "$changes"
+  else
+    echo -e "  ${DIM}(no changes)${NC}"
   fi
 }
 
@@ -64,32 +153,10 @@ _diff_unsaved() {
   echo -e "${CYAN}${BOLD}Unsaved changes: $name${NC}"
   echo ""
 
-  local tmp
-  tmp="$(mktemp -d)" || return 1
-  trap "rm -rf '$tmp'" EXIT
-  if ! _snapshot_live_for_diff "$tmp"; then
-    rm -rf "$tmp"
-    return 1
-  fi
-
-  local diff_args
-  diff_args=(-rq "$profile_dir" "$tmp" --exclude=.git --exclude=.gitignore)
-
-  local changes diff_status=0
-  if ! changes="$(diff "${diff_args[@]}" 2>/dev/null \
-    | sed "s|$profile_dir|profile|g; s|$tmp|current|g")"; then
-    diff_status=$?
-    if [[ $diff_status -gt 1 ]]; then
-      rm -rf "$tmp"
-      return "$diff_status"
-    fi
-  fi
-  rm -rf "$tmp"
-
-  if [[ -n "$changes" ]]; then
-    echo "$changes"
+  if [[ "$(get_current)" == "$name" ]]; then
+    _diff_active_unsaved "$profile_dir"
   else
-    echo -e "  ${DIM}(no changes)${NC}"
+    _diff_profile_unsaved "$profile_dir"
   fi
 }
 

--- a/commands/history.sh
+++ b/commands/history.sh
@@ -41,7 +41,6 @@ cmd_diff() {
 
 _snapshot_live_for_diff() {
   local dst="$1"
-  # Copy all CLAUDE_DIR contents
   local f
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     local base
@@ -53,9 +52,8 @@ _snapshot_live_for_diff() {
       cp -RL "$f" "$dst/$base" || return 1
     fi
   done
-  # Special: copy ~/.claude.json
   if [[ -e "$HOME/.claude.json" ]]; then
-    cp -RL "$HOME/.claude.json" "$dst/.claude.json" || return 1
+    cp -L "$HOME/.claude.json" "$dst/.claude.json" || return 1
   fi
 }
 
@@ -93,10 +91,7 @@ _prepare_diff_baseline_repo() {
   fi
   rm -f "$repo/.gitignore"
   git -C "$repo" add -A -- . || return 1
-  git -C "$repo" \
-    -c user.name=claude-profile \
-    -c user.email=claude-profile@example.invalid \
-    commit -q -m "Diff baseline" --allow-empty || return 1
+  git -C "$repo" commit -q -m "Diff baseline" --allow-empty || return 1
 }
 
 _diff_git_status() {
@@ -105,31 +100,8 @@ _diff_git_status() {
     | sed 's/^/  /'
 }
 
-_diff_active_unsaved() {
-  local profile_dir="$1"
-  local tmp repo changes
-  tmp="$(mktemp -d)" || return 1
-  trap "rm -rf '$tmp'" EXIT
-
-  repo="$tmp/repo"
-  mkdir -p "$repo"
-  if ! _prepare_diff_baseline_repo "$profile_dir" "$repo"; then
-    rm -rf "$tmp"
-    return 1
-  fi
-
-  _clear_diff_worktree "$repo"
-  if ! _snapshot_live_for_diff "$repo"; then
-    rm -rf "$tmp"
-    return 1
-  fi
-
-  changes="$(_diff_git_status "$repo")" || {
-    rm -rf "$tmp"
-    return 1
-  }
-  rm -rf "$tmp"
-
+_print_diff_changes() {
+  local changes="$1"
   if [[ -n "$changes" ]]; then
     echo "$changes"
   else
@@ -137,15 +109,33 @@ _diff_active_unsaved() {
   fi
 }
 
+# Status of live files against the active profile's committed baseline.
+# Rebuilds the baseline in $repo, overlays the live snapshot, then diffs —
+# this catches deletions that comparing against the thin profile dir misses.
+_active_diff_status() {
+  local profile_dir="$1" repo="$2"
+  mkdir -p "$repo" || return 1
+  _prepare_diff_baseline_repo "$profile_dir" "$repo" || return 1
+  _clear_diff_worktree "$repo" || return 1
+  _snapshot_live_for_diff "$repo" || return 1
+  _diff_git_status "$repo"
+}
+
+_diff_active_unsaved() {
+  local profile_dir="$1"
+  local tmp changes rc=0
+  tmp="$(mktemp -d)" || return 1
+
+  changes="$(_active_diff_status "$profile_dir" "$tmp/repo")" || rc=$?
+  rm -rf "$tmp"
+  [[ "$rc" -eq 0 ]] || return "$rc"
+
+  _print_diff_changes "$changes"
+}
+
 _diff_profile_unsaved() {
   local profile_dir="$1"
-  local changes
-  changes="$(_diff_git_status "$profile_dir")" || return 1
-  if [[ -n "$changes" ]]; then
-    echo "$changes"
-  else
-    echo -e "  ${DIM}(no changes)${NC}"
-  fi
+  _print_diff_changes "$(_diff_git_status "$profile_dir")"
 }
 
 _diff_unsaved() {

--- a/commands/info.sh
+++ b/commands/info.sh
@@ -41,7 +41,7 @@ cmd_show() {
   _require_profile_exists "$name"
 
   echo -e "${CYAN}${BOLD}$name${NC}"
-  _show_summary "$PROFILES_DIR/$name"
+  _show_profile_summary "$name"
 }
 
 cmd_edit() {

--- a/commands/profile.sh
+++ b/commands/profile.sh
@@ -63,7 +63,7 @@ cmd_fork() {
 
   set_current "$name"
   ok "Created and activated $(_pname "$name")"
-  _show_summary "$profile_dir"
+  _show_profile_summary "$name"
 }
 
 cmd_use() {
@@ -101,7 +101,7 @@ cmd_use() {
 
   set_current "$name"
   ok "Active profile: $(_pname "$name")"
-  _show_summary "$profile_dir"
+  _show_profile_summary "$name"
 }
 
 cmd_save() {

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -218,7 +218,6 @@ _restore_from_backup() {
   _load_profile_to_live "$backup_dir"
 }
 
-# Print one summary row.
 _show_summary_item() {
   local path="$1" label="$2"
   if [[ -d "$path" ]]; then

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -218,7 +218,19 @@ _restore_from_backup() {
   _load_profile_to_live "$backup_dir"
 }
 
-# Print a summary of what a profile directory contains.
+# Print one summary row.
+_show_summary_item() {
+  local path="$1" label="$2"
+  if [[ -d "$path" ]]; then
+    local count
+    count="$(find "$path" -mindepth 1 -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')"
+    echo -e "  ${GREEN}✓${NC} ${BOLD}$label${NC} ${DIM}($count items)${NC}"
+  elif [[ -f "$path" ]]; then
+    echo -e "  ${GREEN}✓${NC} ${BOLD}$label${NC}"
+  fi
+}
+
+# Print a summary of what a profile directory physically contains.
 _show_summary() {
   local dir="$1"
   local f
@@ -228,12 +240,34 @@ _show_summary() {
     if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
       continue
     fi
-    if [[ -d "$f" ]]; then
-      local count
-      count="$(find "$f" -mindepth 1 -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')"
-      echo -e "  ${GREEN}✓${NC} ${BOLD}$base${NC} ${DIM}($count items)${NC}"
-    elif [[ -f "$f" ]]; then
-      echo -e "  ${GREEN}✓${NC} ${BOLD}$base${NC}"
-    fi
+    _show_summary_item "$f" "$base"
   done
+}
+
+# Print a summary of the active profile's live files. After `use --move`,
+# these are the active profile contents; the profile directory is thin.
+_show_live_summary() {
+  local f
+  for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
+    local base
+    base="$(basename "$f")"
+    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
+      continue
+    fi
+    _show_summary_item "$f" "$base"
+  done
+
+  if [[ -e "$HOME/.claude.json" ]]; then
+    _show_summary_item "$HOME/.claude.json" ".claude.json"
+  fi
+}
+
+# Print the logical contents of a profile, accounting for a moved-thin active dir.
+_show_profile_summary() {
+  local name="$1"
+  if [[ "$(get_current)" == "$name" ]]; then
+    _show_live_summary
+  else
+    _show_summary "$PROFILES_DIR/$name"
+  fi
 }

--- a/tests/diff.bats
+++ b/tests/diff.bats
@@ -9,10 +9,32 @@ load test_helper
   [[ "$output" == *"no changes"* ]]
 }
 
+@test "no changes after switching into a moved-thin active profile" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+  run_cli_ok use alpha
+
+  run_cli diff
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no changes"* ]]
+}
+
 @test "detects unsaved changes" {
   run_cli_ok fork default
   run_cli_ok use default
   echo '{"unsaved": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli diff
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"settings.json"* ]]
+}
+
+@test "detects deleted files after switching into a moved-thin active profile" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+  run_cli_ok use alpha
+
+  rm "$CLAUDE_CODE_HOME/settings.json"
+
   run_cli diff
   [ "$status" -eq 0 ]
   [[ "$output" == *"settings.json"* ]]

--- a/tests/diff.bats
+++ b/tests/diff.bats
@@ -40,6 +40,39 @@ load test_helper
   [[ "$output" == *"settings.json"* ]]
 }
 
+@test "ignores gitignored data dirs for a moved-thin active profile" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+  run_cli_ok use alpha
+
+  # Untracked data that the static .gitignore excludes (see GITIGNORE_CONTENT)
+  mkdir -p "$CLAUDE_CODE_HOME/projects/big"
+  echo "huge" > "$CLAUDE_CODE_HOME/projects/big/data.bin"
+  echo "log" > "$CLAUDE_CODE_HOME/history.jsonl"
+  # ...plus one real, tracked change
+  echo '{"changed": true}' > "$CLAUDE_CODE_HOME/settings.json"
+
+  run_cli diff
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"settings.json"* ]]
+  [[ "$output" != *"projects"* ]]
+  [[ "$output" != *"history.jsonl"* ]]
+}
+
+@test "non-active profile reports its own state, not live" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta   # beta is now active; alpha is not
+
+  # Mutate the ACTIVE profile's live state
+  echo '{"changed": true}' > "$CLAUDE_CODE_HOME/settings.json"
+
+  # Diffing the NON-active alpha must reflect alpha's own git state,
+  # not pick up beta's live changes
+  run_cli diff alpha
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no changes"* ]]
+}
+
 @test "with commit ref shows git diff" {
   run_cli_ok fork default
   run_cli_ok use default

--- a/tests/show.bats
+++ b/tests/show.bats
@@ -9,6 +9,19 @@ load test_helper
   [[ "$output" == *".claude.json"* ]]
 }
 
+@test "shows active live contents after profile directory is moved thin" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+  run_cli_ok use alpha
+
+  run_cli show alpha
+  [[ "$status" -eq 0 \
+    && "$output" == *"alpha"* \
+    && "$output" == *"settings.json"* \
+    && "$output" == *"skills"* \
+    && "$output" == *".claude.json"* ]]
+}
+
 @test "fails on nonexistent" {
   run_cli show nope
   [ "$status" -ne 0 ]

--- a/tests/use.bats
+++ b/tests/use.bats
@@ -81,3 +81,15 @@ load test_helper
   [ -f "$HOME/.claude.json" ]
   grep -q '"mcpServers"' "$HOME/.claude.json"
 }
+
+@test "use: summary shows live contents after target profile is moved thin" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+
+  run_cli use alpha
+  [[ "$status" -eq 0 \
+    && "$output" == *"Active profile: alpha"* \
+    && "$output" == *"settings.json"* \
+    && "$output" == *"skills"* \
+    && "$output" == *".claude.json"* ]]
+}


### PR DESCRIPTION
## What changed

This fixes read paths that inspected an active profile after `use` had moved that profile's files into the live Claude config directory.

- Added a logical profile summary path that reads live `~/.claude/` plus `$HOME/.claude.json` when the requested profile is currently active.
- Updated `use`, `fork`, and `show` to use that logical summary instead of always summarizing the physical profile directory.
- Reworked unsaved `diff` for the active profile to compare the live state against the profile's git baseline, rather than comparing live files against the deliberately thin profile directory.
- Added regression tests for switched-into active profiles, including clean diffs and deleted tracked files.

## Root cause

The switch path intentionally uses `--move` for speed. After `claude-profile use <name>`, most of `<profile-dir>/<name>/` is supposed to be thin because the active profile's content now lives in `~/.claude/`.

That invariant is correct, but several read-only paths treated the physical profile directory as if it were still complete. As a result:

- `use` could print a summary missing live files such as `settings.json` and `skills/`.
- `show <active>` could display the thin profile directory instead of the active profile's actual contents.
- `diff` could report false changes immediately after a clean switch, and could miss deletions when both the live file and thin profile-dir file were absent.

## Impact

Active profiles now behave consistently whether they are full because they were just saved or forked, or thin because they were loaded with `use --move`. The move-vs-copy performance design is preserved.

## Validation

- `bash -n` on modified shell files
- `git diff --check`
- `bats tests/`
- `bats --filter "remote-install" tests/install.bats` with network access enabled
