### PR TITLE
Fix: validate `.current` in `save` so a corrupt marker errors clearly

### DIFF
--- a/commands/profile.sh
+++ b/commands/profile.sh
@@ -113,7 +113,7 @@ cmd_save() {
     esac
   done
 
-  name="${name:-$(get_current)}"
+  name="${name:-$(get_current_validated)}"
   _require_profile_name "$name" "claude-profile save [name] [-m message]"
   _ensure_original_backup
 


### PR DESCRIPTION
## What

`cmd_save` now resolves the default profile name with `get_current_validated` instead of plain `get_current`.

## Why

Every other mutating command — `new`, `fork`, `use`, `deactivate` — already resolves the active profile through `get_current_validated`, which rejects a corrupted `.current` marker (e.g. a path-traversal value such as `../../evil` planted by filesystem corruption) with a clear ".current file is corrupt" message plus recovery guidance.

`cmd_save` was the one mutating command left on plain `get_current` — a gap from the `.current` hardening in `7ad6320`. With a corrupt `.current`, `save` (defaulting to the active profile) fell through to the generic `_validate_profile_name` path, producing a less specific error. This left the existing regression test `tests/corrupt_current.bats` → *"save: corrupt .current triggers clear error when defaulting to current"* **failing on `main`**.

The protection itself was never bypassed — `save` still refused and wrote nothing outside the profiles dir — but the error path was wrong and the test was red.

## Change

- `commands/profile.sh`: `name="${name:-$(get_current)}"` → `name="${name:-$(get_current_validated)}"`

## Testing

- The existing `corrupt_current.bats` *"save: corrupt .current …"* test now passes (was failing on `main`).
- Full suite: **186 passing, 0 failing** (was 185/1 on `main`).