### PR TITLE
Fix: never ingest or delete a user's `~/.claude/.git`; centralize skip rule

### DIFF
--- a/lib/files.sh
+++ b/lib/files.sh
@@ -40,7 +40,9 @@ _snapshot_current() {
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     local base
     base="$(basename "$f")"
-    if [[ "$base" == "." || "$base" == ".." ]]; then
+    # Skip a user-managed .git/.gitignore — the tool manages its own in
+    # profile dirs and must never ingest the user's repository history.
+    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
       continue
     fi
     if [[ -e "$f" ]]; then
@@ -64,7 +66,9 @@ _save_current_to() {
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     local base
     base="$(basename "$f")"
-    if [[ "$base" == "." || "$base" == ".." ]]; then
+    # Skip a user-managed .git/.gitignore in live ~/.claude/ so we neither
+    # ingest the user's repo nor clobber the profile's own .git/.gitignore.
+    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
       continue
     fi
     if [[ -e "$f" ]]; then

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -1,5 +1,21 @@
 # files.sh — Full-directory operations between live ~/.claude/ and profile directories
 
+# Directory entries the tool never copies, moves, or deletes when syncing
+# between live ~/.claude/ and profile dirs:
+#   .  ..            directory self / parent
+#   .git .gitignore  git metadata. Profile dirs carry the tool's OWN (written
+#                    by _git_init); any .git/.gitignore in live ~/.claude/ is
+#                    the USER's, left wholly untouched — never ingested into a
+#                    profile, never clobbered, never deleted.
+# To skip another entry everywhere, add one pattern below; every copy/move/
+# clear/summary loop runs through this predicate.
+_skip_entry() {
+  case "$1" in
+    . | .. | .git | .gitignore) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Seed a new (empty) profile with template files.
 # Uses $PROFILES_DIR/.seed/ if it exists, otherwise falls back to built-in defaults.
 _seed_profile() {
@@ -10,7 +26,7 @@ _seed_profile() {
     for f in "$seed_dir"/* "$seed_dir"/.*; do
       local base
       base="$(basename "$f")"
-      if [[ "$base" == "." || "$base" == ".." ]]; then
+      if _skip_entry "$base"; then
         continue
       fi
       if [[ -e "$f" ]]; then
@@ -40,9 +56,7 @@ _snapshot_current() {
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     local base
     base="$(basename "$f")"
-    # Skip a user-managed .git/.gitignore — the tool manages its own in
-    # profile dirs and must never ingest the user's repository history.
-    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
+    if _skip_entry "$base"; then
       continue
     fi
     if [[ -e "$f" ]]; then
@@ -66,9 +80,7 @@ _save_current_to() {
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     local base
     base="$(basename "$f")"
-    # Skip a user-managed .git/.gitignore in live ~/.claude/ so we neither
-    # ingest the user's repo nor clobber the profile's own .git/.gitignore.
-    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
+    if _skip_entry "$base"; then
       continue
     fi
     if [[ -e "$f" ]]; then
@@ -129,7 +141,7 @@ _validate_profile_for_load() {
   for f in "$profile_dir"/* "$profile_dir"/.*; do
     local base
     base="$(basename "$f")"
-    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
+    if _skip_entry "$base"; then
       continue
     fi
     if [[ -L "$f" ]]; then
@@ -172,7 +184,7 @@ _load_profile_to_live() {
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     local base
     base="$(basename "$f")"
-    if [[ "$base" == "." || "$base" == ".." ]]; then
+    if _skip_entry "$base"; then
       continue
     fi
     if [[ -L "$f" || -e "$f" ]]; then
@@ -188,7 +200,7 @@ _load_profile_to_live() {
   for f in "$profile_dir"/* "$profile_dir"/.*; do
     local base
     base="$(basename "$f")"
-    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
+    if _skip_entry "$base"; then
       continue
     fi
     # Handle .claude.json specially — goes to $HOME/.claude.json
@@ -240,7 +252,7 @@ _show_summary() {
   for f in "$dir"/* "$dir"/.*; do
     local base
     base="$(basename "$f")"
-    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
+    if _skip_entry "$base"; then
       continue
     fi
     _show_summary_item "$f" "$base"
@@ -254,7 +266,7 @@ _show_live_summary() {
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     local base
     base="$(basename "$f")"
-    if [[ "$base" == "." || "$base" == ".." || "$base" == ".git" || "$base" == ".gitignore" ]]; then
+    if _skip_entry "$base"; then
       continue
     fi
     _show_summary_item "$f" "$base"

--- a/tests/data_safety.bats
+++ b/tests/data_safety.bats
@@ -448,3 +448,52 @@ JSON
   [ ! -L "$CLAUDE_CODE_HOME/agents" ]
   grep -q "agent content" "$CLAUDE_CODE_HOME/agents/payload.md"
 }
+
+# ─── User-managed ~/.claude/.git is not ingested into profiles ──
+
+@test "fork: does not ingest a user-managed ~/.claude/.git" {
+  # User version-controls their own ~/.claude/ (a normal dotfiles practice)
+  git -C "$CLAUDE_CODE_HOME" init -q
+  git -C "$CLAUDE_CODE_HOME" add -A
+  git -C "$CLAUDE_CODE_HOME" commit -q -m "my personal config"
+
+  run_cli_ok fork myprofile
+
+  # The profile must get its OWN baseline commit, not the user's history
+  local log
+  log="$(git -C "$(profile_dir myprofile)" log --oneline)"
+  [[ "$log" == *"Profile created"* ]]
+  [[ "$log" != *"my personal config"* ]]
+}
+
+@test "fork: profile keeps the static .gitignore even when ~/.claude has a .git" {
+  git -C "$CLAUDE_CODE_HOME" init -q
+  git -C "$CLAUDE_CODE_HOME" add -A
+  git -C "$CLAUDE_CODE_HOME" commit -q -m "my personal config"
+
+  run_cli_ok fork myprofile
+
+  # The static .gitignore must be present so large data dirs stay untracked
+  [ -f "$(profile_dir myprofile)/.gitignore" ]
+  grep -q '/projects' "$(profile_dir myprofile)/.gitignore"
+}
+
+@test "save: does not overwrite the profile's own .git with a live ~/.claude/.git" {
+  run_cli_ok fork myprofile
+  run_cli_ok use myprofile
+
+  # User starts version-controlling their live ~/.claude/ AFTER activating
+  git -C "$CLAUDE_CODE_HOME" init -q
+  git -C "$CLAUDE_CODE_HOME" add -A
+  git -C "$CLAUDE_CODE_HOME" commit -q -m "my personal config"
+
+  # Change a tracked file and save
+  echo '{"changed": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok save -m "x"
+
+  # The profile's own baseline history must survive (not be clobbered)
+  local log
+  log="$(git -C "$(profile_dir myprofile)" log --oneline)"
+  [[ "$log" == *"Profile created"* ]]
+  [[ "$log" != *"my personal config"* ]]
+}

--- a/tests/data_safety.bats
+++ b/tests/data_safety.bats
@@ -497,3 +497,47 @@ JSON
   [[ "$log" == *"Profile created"* ]]
   [[ "$log" != *"my personal config"* ]]
 }
+
+# ─── User-managed ~/.claude/.git survives the load path (switch/restore) ──
+
+@test "use: preserves a user-managed ~/.claude/.git across a profile switch" {
+  # User version-controls their own ~/.claude/ (a normal dotfiles practice)
+  git -C "$CLAUDE_CODE_HOME" init -q
+  git -C "$CLAUDE_CODE_HOME" add -A
+  git -C "$CLAUDE_CODE_HOME" commit -q -m "my personal config"
+
+  # Two profiles so `use` performs a REAL switch: fork sets the active
+  # profile, so after forking both, profB is active and `use profA` is a
+  # genuine profB→profA switch that runs the load path's clear loop.
+  run_cli_ok fork profA
+  run_cli_ok fork profB
+  run_cli_ok use profA
+
+  # The user's repo must still live in ~/.claude/ and be untouched — the
+  # switch must neither delete it nor replace it with tool history.
+  [ -d "$CLAUDE_CODE_HOME/.git" ]
+  local log
+  log="$(git -C "$CLAUDE_CODE_HOME" log --oneline)"
+  [[ "$log" == *"my personal config"* ]]
+  [[ "$log" != *"Profile created"* ]]
+}
+
+@test "deactivate: preserves a user-managed ~/.claude/.git" {
+  run_cli_ok fork myprofile
+  run_cli_ok use myprofile
+
+  # User starts version-controlling their live ~/.claude/ AFTER activating
+  git -C "$CLAUDE_CODE_HOME" init -q
+  git -C "$CLAUDE_CODE_HOME" add -A
+  git -C "$CLAUDE_CODE_HOME" commit -q -m "my personal config"
+
+  run_cli_ok deactivate
+
+  # deactivate restores the pre-profiles backup; the user's own repo (added
+  # later, living in ~/.claude/) must survive that restore, not be wiped.
+  [ -d "$CLAUDE_CODE_HOME/.git" ]
+  local log
+  log="$(git -C "$CLAUDE_CODE_HOME" log --oneline)"
+  [[ "$log" == *"my personal config"* ]]
+  [[ "$log" != *"Profile created"* ]]
+}


### PR DESCRIPTION
## What

Protect a user-managed `~/.claude/.git` from the profile machinery on **both** sides — capture (don't ingest it) and load (don't delete it) — and centralize the directory-entry skip rule so the two sides can't drift apart again.

## Why

`~/.claude/` is sometimes the user's own git repo (a normal dotfiles practice). The tool keeps its own git history *inside each profile dir*, so it must treat a user's `~/.claude/.git` as orthogonal: never ingest, never clobber, never delete. Two asymmetric loops broke that:

1. **Capture ingested it.** `_snapshot_current` / `_save_current_to` (live → profile) skipped only `.`/`..`, while the load loop already skipped `.git`/`.gitignore`. So a user's `~/.claude/.git` was pulled into a profile dir — `_git_init` then saw an existing `.git` and skipped the profile's own `Profile created` baseline **and** the static `.gitignore` (which keeps large data dirs out of history); `_save_current_to` ran `rm -rf "$dst/.git"` and clobbered the profile's history. On restore the load path skipped `.git`, so the repo was never restored — silent loss.

2. **Load deleted it.** `_load_profile_to_live` clears live `~/.claude/` by removing every entry except `.`/`..` — it did **not** skip `.git`, even though the copy loop directly below it does. So once capture stopped ingesting `.git` (correctly leaving it in live), a `use` switch or `deactivate` `rm -rf`'d the user's repo outright. Verified empirically: a real profile→profile switch deleted `~/.claude/.git`.

## Change

- **`_skip_entry` helper** (`lib/files.sh`): one `case`-based predicate for `. .. .git .gitignore`. All **eight** copy/move/clear/summary loops route through it — previously six duplicated the full four-way chain and two skipped only `.`/`..`. `case` keeps it `set -e`-safe; extending the skip set is now a one-line edit in one place.
- The `_load_profile_to_live` **clear loop** now skips `.git`/`.gitignore` via `_skip_entry` — the data-loss fix, making it symmetric with the copy loop in the same function.

## Testing

5 tests in `tests/data_safety.bats` — 3 capture-side, 2 load-side:
- `fork: does not ingest a user-managed ~/.claude/.git`
- `fork: profile keeps the static .gitignore even when ~/.claude has a .git`
- `save: does not overwrite the profile's own .git with a live ~/.claude/.git`
- `use: preserves a user-managed ~/.claude/.git across a profile switch`
- `deactivate: preserves a user-managed ~/.claude/.git`

Each load-side test was verified **red** before the clear-loop fix, **green** after. Rebased on current `main`; full suite green (**201/201**).
