### PR TITLE
Fix: match the install dir literally in installer PATH check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -189,7 +189,7 @@ fi
 "$INSTALL_DIR/claude-profile" statusline install
 
 # ─── Check PATH ─────────────────────────────────────────────
-if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+if ! echo "$PATH" | tr ':' '\n' | grep -Fqx "$INSTALL_DIR"; then
   echo ""
   echo -e "${BOLD}Add to your PATH:${NC}"
   echo ""

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -254,6 +254,19 @@ EOF
   [[ "$output" == *"Add to your PATH"* ]]
 }
 
+@test "PATH check: suppresses hint when the install dir is exactly on PATH" {
+  # The mirror of the near-miss case: the dir still contains a '.', but this
+  # time it is literally on PATH. The hint must be suppressed — proving the
+  # fixed-string match still treats '.' as a real '.' and did not over-correct
+  # into always showing the hint.
+  export CLAUDE_PROFILE_INSTALL_DIR="$BATS_TEST_TMPDIR/a.b/bin"
+  mkdir -p "$CLAUDE_PROFILE_INSTALL_DIR"
+
+  PATH="$CLAUDE_PROFILE_INSTALL_DIR:$PATH" run bash "$REPO_DIR/install.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Add to your PATH"* ]]
+}
+
 # ─── Sed injection safety (install path with special chars) ──
 
 @test "install: handles pipe character in install path" {

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -237,6 +237,23 @@ EOF
   grep -q '# <<< claude-profile completions <<<' "$HOME/.bashrc"
 }
 
+# ─── PATH check uses literal (fixed-string) matching ────────
+
+@test "PATH check: shows hint when only a regex near-miss is on PATH" {
+  # INSTALL_DIR contains a '.' (regex metachar). A near-miss entry where a
+  # different char sits in the '.' position must NOT count as the dir being on
+  # PATH — otherwise the hint is wrongly suppressed (grep -qx vs grep -Fqx).
+  export CLAUDE_PROFILE_INSTALL_DIR="$BATS_TEST_TMPDIR/a.b/bin"
+  mkdir -p "$CLAUDE_PROFILE_INSTALL_DIR"
+
+  # Near-miss: same length, 'X' where the '.' is. The real INSTALL_DIR is NOT
+  # literally present. Keep the rest of PATH so cp/awk/grep still resolve.
+  local nearmiss="$BATS_TEST_TMPDIR/aXb/bin"
+  PATH="$nearmiss:$PATH" run bash "$REPO_DIR/install.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Add to your PATH"* ]]
+}
+
 # ─── Sed injection safety (install path with special chars) ──
 
 @test "install: handles pipe character in install path" {


### PR DESCRIPTION
## What

Use a fixed-string match (`grep -Fqx`) instead of a regex match (`grep -qx`) when checking whether the install dir is already on `$PATH`.

## Why

The post-install check in `install.sh` was:

```bash
if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
  # print "Add to your PATH" hint
fi
```

`grep -qx "$INSTALL_DIR"` treats `$INSTALL_DIR` as a **regular expression**. The default install dir, `$HOME/.local/bin`, contains a literal `.` — which in a regex matches *any* character. So a PATH entry that differs only where a `.` sits (e.g. `/home/u/Xlocal/bin` vs `/home/u/.local/bin`) can falsely match, making the installer believe the dir is already on `PATH` and **wrongly suppress the "Add to your PATH" hint**. A user could then be left without the hint and a non-working `claude-profile`.

## Change

- `install.sh`: `grep -qx "$INSTALL_DIR"` → `grep -Fqx "$INSTALL_DIR"` (literal match).

## Testing

Two tests in `tests/install.bats` pin **both directions** of the PATH check:

- *"PATH check: shows hint when only a regex near-miss is on PATH"* — install dir `…/a.b/bin` with the regex near-miss `…/aXb/bin` on `PATH`; asserts the hint **is** shown. Fails with `-qx`, passes with `-Fqx` (guards the original false-suppress bug).
- *"PATH check: suppresses hint when the install dir is exactly on PATH"* — the same `…/a.b/bin` dir, this time literally on `PATH`; asserts the hint is **not** shown. Proves the fixed-string match still treats `.` as a real `.` and didn't over-correct into always showing the hint. (Mutation-checked: breaking suppression fails this test while the near-miss test stays green.)

> Note: the full suite on this branch shows **1 failing test** — `corrupt_current.bats` → "save: corrupt .current …". That failure is **pre-existing on `main`** and unrelated to this change; it is fixed by a separate PR (`fix/save-validate-current`).
