### PR TITLE
Fix: cancel `delete` cleanly on EOF instead of aborting

### DIFF
--- a/commands/info.sh
+++ b/commands/info.sh
@@ -82,7 +82,9 @@ cmd_delete() {
   fi
 
   if [[ $force -eq 0 ]]; then
-    read -rp "Delete profile '$name'? [y/N] " confirm
+    if ! read -rp "Delete profile '$name'? [y/N] " confirm; then
+      info "Cancelled"; return
+    fi
     [[ "$confirm" =~ ^[Yy]$ ]] || { info "Cancelled"; return; }
   fi
 

--- a/tests/delete.bats
+++ b/tests/delete.bats
@@ -23,3 +23,14 @@ load test_helper
   [ "$status" -ne 0 ]
   [[ "$output" == *"not found"* ]]
 }
+
+@test "EOF at confirm prompt cancels cleanly without deleting" {
+  run_cli_ok fork victim
+  # fork auto-activates, so switch away so victim is deletable
+  run_cli_ok fork other
+  # delete without -f, with stdin at EOF so read gets no input
+  run_cli delete victim </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Cancelled"* ]]
+  [ -d "$(profile_dir victim)" ]
+}


### PR DESCRIPTION
## What

Guard the confirmation `read` in `cmd_delete` so an EOF cancels cleanly instead of triggering a `set -e` abort.

## Why

The whole CLI runs under `set -euo pipefail`. `cmd_delete` confirms with:

```bash
read -rp "Delete profile '$name'? [y/N] " confirm
[[ "$confirm" =~ ^[Yy]$ ]] || { info "Cancelled"; return; }
```

If the user sends EOF at the prompt — Ctrl-D, or a closed/non-interactive stdin (pipelines, CI) — `read` returns non-zero. Under `set -e` that **aborts the entire script immediately**, so the intended "Cancelled" branch never runs: the command dies with a bare `exit 1` and no message. The profile is correctly *not* deleted, but the cancel is abrupt and silent.

## Change

- `commands/info.sh`: wrap the prompt as `if ! read -rp ... ; then info "Cancelled"; return; fi`, so EOF prints "Cancelled" and returns 0 — mirroring the existing "answer wasn't yes ⇒ cancel" behavior.

## Testing

New test in `tests/delete.bats`: *"EOF at confirm prompt cancels cleanly without deleting"* — runs `delete <profile> </dev/null` (true EOF) and asserts the profile still exists, output contains "Cancelled", and exit status is 0.

> Note: the full suite on this branch shows **1 failing test** — `corrupt_current.bats` → "save: corrupt .current …". That failure is **pre-existing on `main`** and unrelated to this change; it is fixed by a separate PR (`fix/save-validate-current`).