### PR TITLE
Add pre-push hook that gates pushes on the bats suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,19 @@ bats tests/fork.bats    # Run tests for one command
 bats tests/ --tap       # TAP output for CI
 ```
 
+## Git hooks
+
+The repo ships a version-controlled `pre-push` hook (`hooks/pre-push`) that runs
+the full bats suite and **blocks the push if any test fails**. Activate it once
+per clone:
+
+```bash
+./scripts/setup-hooks.sh    # sets core.hooksPath=hooks
+```
+
+Bypass in an emergency with `git push --no-verify`. The hook errors out if `bats`
+isn't installed rather than silently letting an unverified push through.
+
 ## Releasing
 
 Version is defined in `lib/config.sh` as `VERSION="X.Y.Z"`. When creating a new release, **always keep the VERSION variable, git tag, and Homebrew formula in sync**:

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# pre-push hook — run the full bats suite and block the push on any failure.
+#
+# This hook is version-controlled. It is activated per-clone by pointing git at
+# the tracked hooks directory:
+#
+#     git config core.hooksPath hooks
+#
+# (run scripts/setup-hooks.sh once to do that automatically).
+#
+# To push despite red/uninstalled tests in an emergency, bypass with:
+#
+#     git push --no-verify
+#
+set -euo pipefail
+
+RED='\033[0;31m' GREEN='\033[0;32m' YELLOW='\033[0;33m' BOLD='\033[1m' NC='\033[0m'
+
+# Run from the repo root so `tests/` resolves regardless of where git invoked us.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if ! command -v bats >/dev/null 2>&1; then
+  echo -e "${RED}✗ pre-push: bats is not installed — cannot verify tests.${NC}" >&2
+  echo -e "  Install it (e.g. ${BOLD}brew install bats-core${NC}) or bypass with ${BOLD}git push --no-verify${NC}." >&2
+  exit 1
+fi
+
+echo -e "${YELLOW}▸ pre-push: running test suite before push...${NC}"
+
+if bats tests/; then
+  echo -e "${GREEN}✓ pre-push: all tests passed — pushing.${NC}"
+  exit 0
+else
+  echo -e "${RED}✗ pre-push: tests failed — push aborted.${NC}" >&2
+  echo -e "  Fix the failing tests, or bypass with ${BOLD}git push --no-verify${NC} (not recommended)." >&2
+  exit 1
+fi

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# One-time developer setup: activate the version-controlled git hooks in hooks/.
+#
+#     ./scripts/setup-hooks.sh
+#
+# This points git at the tracked hooks directory so pre-push runs the bats suite.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+git config core.hooksPath hooks
+chmod +x hooks/* 2>/dev/null || true
+
+echo "✓ Git hooks activated (core.hooksPath=hooks)."
+echo "  pre-push will now run 'bats tests/' and block pushes on failure."
+echo "  Bypass in an emergency with: git push --no-verify"


### PR DESCRIPTION
## Summary

Adds a version-controlled `pre-push` git hook that runs the full bats suite and **blocks the push if any test fails** — so red tests can never be pushed.

- `hooks/pre-push` — runs `bats tests/` from the repo root; exits non-zero (aborting the push) on any failure, or if `bats` isn't installed (fails loud rather than silently allowing an unverified push).
- `scripts/setup-hooks.sh` — one-time per-clone activator; sets `core.hooksPath=hooks` and marks the hooks executable.
- `CLAUDE.md` — new "Git hooks" section documenting activation and the `git push --no-verify` bypass.

## Why `core.hooksPath` instead of `.git/hooks/`

`.git/hooks/` isn't version-controlled, so a hook placed there wouldn't travel with the repo. Storing the hook in a tracked `hooks/` dir and pointing git at it with `core.hooksPath` means the hook ships with the code and updates flow via normal pulls. The cost is one setup command per clone (`./scripts/setup-hooks.sh`).

## Why `pre-push` (not `pre-commit`)

Gating on push keeps local commits fast — the full suite runs only when you actually publish.

## Verification

- Activated locally via `scripts/setup-hooks.sh`; `core.hooksPath` now resolves to `hooks`.
- The push that created this branch triggered the hook live: all **186 tests passed**, then the push proceeded.
- Green path exits `0`; failure path uses the standard `if bats tests/; then … else exit 1`.

## Note

The hook is not bats-tested: the project's TDD rule governs CLI commands (which run in bats' isolated `$HOME`), whereas this hook is repo infrastructure that wraps the test runner itself. Verified by direct invocation instead.