### PR TITLE
Isolate tests from the caller's git environment

### DIFF
--- a/tests/git_env.bats
+++ b/tests/git_env.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# Regression coverage for Git hook environments. Git launches hooks with
+# repository-local GIT_* variables exported; the test suite must scrub those at
+# load time before any fixture creates commits.
+
+clean_git() (
+  unset $(git rev-parse --local-env-vars 2>/dev/null) \
+        GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM 2>/dev/null || true
+  git "$@"
+)
+
+@test "git environment: suite launch scrubs inherited repository variables" {
+  local repo_root
+  repo_root="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+  local canary="$BATS_TEST_TMPDIR/canary"
+  clean_git init -q "$canary"
+  clean_git -C "$canary" -c user.email=test@test -c user.name=test \
+    commit -q --allow-empty -m CANARY
+
+  local expected_head
+  expected_head="$(clean_git -C "$canary" rev-parse HEAD)"
+
+  run env \
+    GIT_DIR="$canary/.git" \
+    GIT_WORK_TREE="$canary" \
+    GIT_INDEX_FILE="$canary/.git/index" \
+    bats "$repo_root/tests/isolation.bats"
+
+  if [[ "$status" -ne 0 ]]; then
+    echo "$output"
+  fi
+  [ "$status" -eq 0 ]
+
+  [ "$(clean_git -C "$canary" rev-parse HEAD)" = "$expected_head" ]
+  [ "$(clean_git -C "$canary" rev-list --count HEAD)" -eq 1 ]
+
+  local canary_status
+  canary_status="$(clean_git -C "$canary" status --short)"
+  if [[ -n "$canary_status" ]]; then
+    echo "$canary_status"
+  fi
+  [ -z "$canary_status" ]
+}

--- a/tests/isolation.bats
+++ b/tests/isolation.bats
@@ -113,5 +113,5 @@ load test_helper
   # profiles dir, never in some ambient repo.
   run_cli_ok fork probe
   [ -d "$(profile_dir probe)/.git" ]
-  git -C "$(profile_dir probe)" rev-parse --absolute-git-dir | grep -q "$BATS_TEST_TMPDIR"
+  git -C "$(profile_dir probe)" rev-parse --absolute-git-dir | grep -qF "$BATS_TEST_TMPDIR"
 }

--- a/tests/isolation.bats
+++ b/tests/isolation.bats
@@ -98,3 +98,20 @@ load test_helper
   [[ "$HOME" == *"bats"* ]] || [[ "$HOME" == */tmp/* ]]
   [[ "$CLAUDE_CODE_HOME" == *"bats"* ]] || [[ "$CLAUDE_CODE_HOME" == */tmp/* ]]
 }
+
+@test "isolation: tests are immune to an ambient GIT_DIR" {
+  # A git hook (e.g. the pre-push hook) runs with GIT_DIR/GIT_INDEX_FILE
+  # exported. If those leaked into a test, its `git commit`s would write to
+  # the caller's repo instead of the isolated HOME — which once corrupted a
+  # real branch. test_helper.bash scrubs the inherited git environment at
+  # load time so this holds for every test.
+  [ -z "${GIT_DIR:-}" ]
+  [ -z "${GIT_WORK_TREE:-}" ]
+  [ -z "${GIT_INDEX_FILE:-}" ]
+
+  # Behavioural guard: the tool's git operations must land inside the isolated
+  # profiles dir, never in some ambient repo.
+  run_cli_ok fork probe
+  [ -d "$(profile_dir probe)/.git" ]
+  git -C "$(profile_dir probe)" rev-parse --absolute-git-dir | grep -q "$BATS_TEST_TMPDIR"
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -9,6 +9,20 @@
 
 CLAUDE_PROFILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/claude-profile"
 
+# Fully isolate tests from the caller's git environment — done at load time so
+# it covers EVERY test file, including the ones that define their own setup()
+# and never call the shared one (install.bats, uninstall.bats).
+#
+# When bats is launched from a git hook (e.g. pre-push), git exports GIT_DIR,
+# GIT_INDEX_FILE and friends. Left in place, a test's `git commit` would write
+# to the caller's repo instead of the isolated HOME — this once landed fixture
+# commits on a real branch. `git rev-parse --local-env-vars` is git's own
+# authoritative list of repository-local variables, so this stays correct as
+# git evolves; the *_CONFIG_* vars are added so `git config --global` always
+# targets the isolated HOME.
+unset $(git rev-parse --local-env-vars 2>/dev/null) \
+      GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM 2>/dev/null || true
+
 setup() {
   # Isolated home per test
   export HOME="$BATS_TEST_TMPDIR/home"


### PR DESCRIPTION
## What

Make the bats suite fully isolated from the **caller's git environment**, so test git operations can never touch any repo outside their sandboxed `$HOME`.

## Why

The harness isolates `$HOME`, `CLAUDE_CODE_HOME`, etc., but never dropped the **git environment variables** inherited from the process that launched bats. When bats runs from a git hook — notably the `pre-push` hook, which runs the suite — git exports the repository-local vars (`GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, …). With `GIT_DIR` set, a test's `git -C "$isolated_dir" commit` ignores `-C` and writes to the **caller's** repo.

This is not theoretical: while working on another branch, running the suite under a leaked `GIT_DIR` wrote bats fixture commits (`Profile created`, `my personal config`) onto a real branch and required a history rewrite to recover. A test that can reach outside its sandbox is not isolated.

## Fix

Scrub the inherited git environment in `tests/test_helper.bash`, **at load time** rather than inside `setup()`:

```sh
unset $(git rev-parse --local-env-vars 2>/dev/null) \
      GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM 2>/dev/null || true
```

Two deliberate choices:

- **Load time, not `setup()`.** `install.bats` and `uninstall.bats` define their *own* `setup()` and never call the shared one — an `unset` inside the shared `setup()` would silently skip them (and it did, in an earlier draft: `install.bats` still failed under a leaked `GIT_DIR`). Every test file does `load test_helper`, so a load-time scrub covers all of them.
- **`git rev-parse --local-env-vars`**, not a hand-written list. That is git's own authoritative set of repository-local variables, so it stays correct as git evolves (a hand-rolled list was already missing 8 of them). `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` are added so `git config --global` in setup always targets the isolated `$HOME`.

## Testing

New `tests/isolation.bats` test asserts no ambient `GIT_DIR` survives into a test and that the tool's git operations land in the isolated profiles dir.

Verified by running the **entire suite under a leaked `GIT_DIR`** (pointed at a throwaway dir): **197/197 green**, including the `install.bats`/`uninstall.bats` custom-setup tests — and the real branch was left untouched. Normal run: 197/197, no regression.

> Side effect: this also makes the `pre-push` hook reliable. It previously false-failed (every git-touching test) and was the vector that leaked fixture commits; with tests immune to the ambient git env, the hook now runs the suite cleanly.
