### PR TITLE
Refuse to wipe unsaved live config in use/new

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Priority: `CLAUDE_PROFILE_HOME` > `XDG_DATA_HOME/claude-profile` > `$HOME/.local
 
 ### deactivate --keep
 
-`deactivate --keep` detaches from profiles without restoring the backup — the user's current config stays as-is. This is the migration path for when native profiles arrive. Regular `deactivate` restores from `.pre-profiles-backup/`.
+`deactivate --keep` detaches from profiles without restoring the backup — the user's current config stays as-is. This is the migration path for when native profiles arrive. Regular `deactivate` restores from `.pre-profiles-backup/`. While detached, `use`/`new` refuse to overwrite a live config that isn't saved in any profile — `fork` preserves it, `--force` discards it.
 
 ## Development workflow — TDD
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Profiles are stored in `~/.local/share/claude-profile/` (XDG-compliant), separat
 ## Commands
 
 ```
-new <name>              Create a clean empty profile and activate it
+new <name> [--force]    Create a clean empty profile and activate it
 fork <name>             Copy current state into a new profile
-use <name>              Switch to a profile (auto-saves current)
+use <name> [--force]    Switch to a profile (auto-saves current)
 list                    List all profiles, highlight active
 current                 Print active profile name
 show [name]             Show profile contents
@@ -159,6 +159,7 @@ This is configured during installation. If you already have a custom `statusLine
 
 - **Original backup** — your pre-profiles config is backed up on first use and **never modified** by any operation. It's your safety net.
 - **Auto-save on switch** — `use` saves the current profile before switching. No changes are lost.
+- **No silent overwrite when unsaved** — when no profile would auto-save your live config (after `deactivate`, or if the active profile's directory is missing), `use` and `new` refuse to wipe it. Run `claude-profile fork <name>` to preserve it as a profile, or re-run with `--force` to discard it.
 - **Full isolation** — each profile is an independent copy. Changing one never affects another.
 - **Clean exit** — `deactivate` restores your original state. `deactivate --keep` keeps your current config for [migration](#migrating-to-native-claude-code-profiles).
 
@@ -183,6 +184,8 @@ rm -rf ~/.local/share/claude-profile
 ```
 
 `--keep` saves your profile, clears the active marker, and leaves all your files in place — Claude Code sees normal config. Without `--keep`, `deactivate` restores your original pre-profiles config.
+
+While detached, your live config isn't saved in any profile — so if you change your mind and run `use` or `new`, they refuse rather than overwrite it. `fork <name>` re-attaches and preserves it; `--force` discards it.
 
 See the full [migration guide](docs/migration.md) for details and troubleshooting.
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,24 @@ deactivate              Restore original state, turn off profiles
 deactivate --keep       Detach from profiles, keep current config
 ```
 
+### Deactivating and coming back
+
+Two ways out:
+
+```bash
+claude-profile deactivate         # restore your original pre-profiles config
+claude-profile deactivate --keep  # detach, keep the current profile's files live
+```
+
+Both save the active profile first. `deactivate` returns you to the config you had before you first ran `fork`/`new`. `--keep` leaves your files exactly as they are — Claude Code sees a normal config, and your profiles stay saved on disk. This is the path for [migrating to native profiles](#migrating-to-native-claude-code-profiles), or for pausing the tool without changing anything.
+
+While detached, nothing auto-saves your changes — so if your live config isn't saved in any profile, `use` and `new` stop and ask you to decide:
+
+```bash
+claude-profile fork my-setup      # keep it: save as a new profile (re-attaches you)
+claude-profile use work --force   # drop it: switch and discard the detached changes
+```
+
 ### Version history
 
 Every profile has built-in git history. Each save is a commit.

--- a/claude-profile
+++ b/claude-profile
@@ -43,9 +43,10 @@ ${CYAN}${BOLD}USAGE${NC}
   claude-profile ${DIM}<command> [options]${NC}
 
 ${CYAN}${BOLD}COMMANDS${NC}
-  ${BOLD}new${NC} ${DIM}<name>${NC}                    Create a clean empty profile
+  ${BOLD}new${NC} ${DIM}<name> [--force]${NC}          Create a clean empty profile
   ${BOLD}fork${NC} ${DIM}<name>${NC}                   Copy current state into a new profile
-  ${BOLD}use${NC} ${DIM}<name>${NC}                    Switch to a profile
+  ${BOLD}use${NC} ${DIM}<name> [--force]${NC}          Switch to a profile
+                                  ${DIM}--force: discard unsaved detached config${NC}
   ${BOLD}list${NC}                          List all profiles
   ${BOLD}current${NC}                       Show active profile name
   ${BOLD}show${NC} ${DIM}[name]${NC}                   Show profile contents

--- a/commands/profile.sh
+++ b/commands/profile.sh
@@ -1,8 +1,55 @@
 # profile.sh — Core profile operations: new, fork, use, save, deactivate
 
+# Guard for use/new: when the auto-save will not run — no profile is current
+# (detached after deactivate), or .current names a profile dir that no longer
+# exists — loading a profile would destroy live config that is not saved in
+# any profile. Refuse unless --force was given, the live state is empty, the
+# original backup didn't pre-exist (a backup created by this very command
+# captures the live state, so first runs proceed without friction), or the
+# live state is byte-identical to the original backup (e.g. right after a
+# first-command `save` or an untouched deactivate).
+_guard_detached_live_state() {
+  local current="$1" force="$2" backup_preexisted="$3"
+  # Attached counts only when the auto-save will actually run — mirror its
+  # condition exactly: a dangling .current saves nothing.
+  if [[ -n "$current" && -d "$PROFILES_DIR/$current" ]]; then
+    return 0
+  fi
+  if [[ "$force" == true || "$backup_preexisted" != true ]]; then
+    return 0
+  fi
+  if ! _live_state_nonempty; then
+    return 0
+  fi
+  if _live_state_equals_dir "$PROFILES_DIR/.pre-profiles-backup"; then
+    return 0
+  fi
+  if [[ -n "$current" ]]; then
+    err "Active profile '$(_pname "$current")' is missing — your live config is not saved in any profile"
+  else
+    err "No active profile — your current live config is not saved in any profile"
+  fi
+  info "Run 'claude-profile fork <name>' to preserve it as a new profile,"
+  info "or re-run with --force to discard it."
+  exit 1
+}
+
 cmd_new() {
-  local name="${1:-}"
-  _require_profile_name "$name" "claude-profile new <name>"
+  local name="" force=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force) force=true; shift ;;
+      *)       name="$1"; shift ;;
+    esac
+  done
+  _require_profile_name "$name" "claude-profile new <name> [--force]"
+
+  # Capture before _ensure_original_backup — a pre-existing backup does NOT
+  # cover config created later, so it can't justify wiping the live state.
+  local backup_preexisted=false
+  if [[ -d "$PROFILES_DIR/.pre-profiles-backup" ]]; then
+    backup_preexisted=true
+  fi
   _ensure_original_backup
 
   local profile_dir="$PROFILES_DIR/$name"
@@ -13,6 +60,7 @@ cmd_new() {
   # Auto-save current profile before switching
   local current
   current="$(get_current_validated)"
+  _guard_detached_live_state "$current" "$force" "$backup_preexisted"
   if [[ -n "$current" && -d "$PROFILES_DIR/$current" ]]; then
     info "Saving profile $(_pname "$current")..."
     _save_current_to "$PROFILES_DIR/$current" "Auto-save before new '$name'" --move
@@ -67,8 +115,14 @@ cmd_fork() {
 }
 
 cmd_use() {
-  local name="${1:-}"
-  _require_profile_name "$name" "claude-profile use <name>"
+  local name="" force=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force) force=true; shift ;;
+      *)       name="$1"; shift ;;
+    esac
+  done
+  _require_profile_name "$name" "claude-profile use <name> [--force]"
 
   local profile_dir="$PROFILES_DIR/$name"
   if [[ ! -d "$profile_dir" ]]; then
@@ -85,7 +139,15 @@ cmd_use() {
     return
   fi
 
+  # Capture before _ensure_original_backup — a pre-existing backup does NOT
+  # cover config created later, so it can't justify wiping the live state.
+  local backup_preexisted=false
+  if [[ -d "$PROFILES_DIR/.pre-profiles-backup" ]]; then
+    backup_preexisted=true
+  fi
   _ensure_original_backup
+
+  _guard_detached_live_state "$current" "$force" "$backup_preexisted"
 
   # Pre-validate target profile before any destructive operations
   _validate_profile_for_load "$profile_dir" || exit 1

--- a/completions/claude-profile.bash
+++ b/completions/claude-profile.bash
@@ -26,12 +26,27 @@ _claude_profile_completions() {
   fi
 
   case "${COMP_WORDS[1]}" in
-    use|switch|edit|show|info|delete|rm|save|history|log|diff|restore)
+    use|switch)
+      # --force only once a dash is typed; profiles otherwise (also after --force)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "--force" -- "$cur"))
+      elif [[ ${COMP_CWORD} -eq 2 || "$prev" == "--force" ]]; then
+        COMPREPLY=($(compgen -W "$profiles" -- "$cur"))
+      fi
+      ;;
+    edit|show|info|delete|rm|save|history|log|diff|restore)
       if [[ ${COMP_CWORD} -eq 2 ]]; then
         COMPREPLY=($(compgen -W "$profiles" -- "$cur"))
       fi
       ;;
-    new|fork)
+    new)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "--force" -- "$cur"))
+      else
+        COMPREPLY=()  # free-form name
+      fi
+      ;;
+    fork)
       COMPREPLY=()  # free-form name
       ;;
     statusline)

--- a/completions/claude-profile.zsh
+++ b/completions/claude-profile.zsh
@@ -42,10 +42,20 @@ _claude-profile() {
     _describe 'command' commands
   elif (( CURRENT == 3 )); then
     case "${words[2]}" in
-      use|switch|edit|show|info|delete|rm|save|history|log|diff|restore)
+      use|switch)
+        local -a flags=('--force:Discard unsaved detached config')
+        _describe 'option' flags
         _claude_profile_profiles
         ;;
-      new|fork)
+      edit|show|info|delete|rm|save|history|log|diff|restore)
+        _claude_profile_profiles
+        ;;
+      new)
+        local -a flags=('--force:Discard unsaved detached config')
+        _describe 'option' flags
+        _message 'profile name'
+        ;;
+      fork)
         _message 'profile name'
         ;;
       statusline)
@@ -55,7 +65,10 @@ _claude-profile() {
     esac
   elif (( CURRENT >= 4 )); then
     case "${words[2]}" in
-      # no further completions needed for new/fork
+      use|switch)
+        # --force may precede the name — keep offering profiles
+        _claude_profile_profiles
+        ;;
     esac
   fi
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ Creates a clean empty profile.
 
 ```
 1. _ensure_original_backup()
-2. _guard_detached_live_state()  ← refuse if unsaved live state would be wiped
+2. _guard_detached_live_state()  ← refuse if the live state isn't saved anywhere
 3. Auto-save current profile     ← --move (since we're switching away)
 4. mkdir profile dir
 5. _seed_profile()               ← copy from .seed/ or built-in defaults
@@ -141,7 +141,7 @@ Creates a clean empty profile.
 The core operation. Uses `--move` for speed.
 
 ```
-1. _guard_detached_live_state()         ← refuse if unsaved live state would be wiped
+1. _guard_detached_live_state()         ← refuse if the live state isn't saved anywhere
 2. _validate_profile_for_load(target)   ← pre-check before destructive ops
 3. _save_current_to(current, --move)
    ├── mv all items: ~/.claude/ → current profile dir
@@ -236,7 +236,7 @@ Git operations for version history:
 Core operations: `new`, `fork`, `use`, `save`, `deactivate`. All follow the same pattern:
 1. Validate input
 2. Ensure backup exists
-3. Guard: refuse if unsaved live state would be wiped (`use`/`new`)
+3. Guard: refuse if the live state isn't saved anywhere (`use`/`new`)
 4. Auto-save current profile if needed
 5. Perform the operation
 6. Update `.current`
@@ -255,7 +255,7 @@ Created once by `_backup_raw_state()` on first `fork` or `new`. Never modified a
 
 Every operation that changes the active profile (`use`, `new`, `deactivate`) saves the current profile first. The user never loses unsaved changes.
 
-When nothing would auto-save the live state — no profile is current (detached after `deactivate`), or `.current` names a profile dir that no longer exists — `use` and `new` refuse instead of wiping it (`_guard_detached_live_state` in `commands/profile.sh`). They proceed only with `--force`, when the live state is empty, when it is byte-identical to the original backup, or when the backup was created by that very command (first run — the fresh backup captures the live state). `fork <name>` is the rescue path: it preserves the detached live state as a profile and re-attaches.
+When nothing would auto-save the live state — no profile is current (detached after `deactivate`), or `.current` names a profile dir that no longer exists — `use` and `new` refuse to proceed (`_guard_detached_live_state` in `commands/profile.sh`). They go ahead only with `--force`, when the live state is empty, when it is byte-identical to the original backup, or when the backup was created by that very command (first run — the fresh backup captures the live state). `fork <name>` preserves a detached live state as a profile and re-attaches.
 
 ### Pre-validation before destructive switch
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,12 +127,13 @@ Creates a clean empty profile.
 
 ```
 1. _ensure_original_backup()
-2. Auto-save current profile     ← --move (since we're switching away)
-3. mkdir profile dir
-4. _seed_profile()               ← copy from .seed/ or built-in defaults
-5. _git_init()
-6. _load_profile_to_live()       ← cp from profile to live
-7. set_current()
+2. _guard_detached_live_state()  ← refuse if unsaved live state would be wiped
+3. Auto-save current profile     ← --move (since we're switching away)
+4. mkdir profile dir
+5. _seed_profile()               ← copy from .seed/ or built-in defaults
+6. _git_init()
+7. _load_profile_to_live()       ← cp from profile to live
+8. set_current()
 ```
 
 ### `use <name>` (switch)
@@ -140,16 +141,17 @@ Creates a clean empty profile.
 The core operation. Uses `--move` for speed.
 
 ```
-1. _validate_profile_for_load(target)   ← pre-check before destructive ops
-2. _save_current_to(current, --move)
+1. _guard_detached_live_state()         ← refuse if unsaved live state would be wiped
+2. _validate_profile_for_load(target)   ← pre-check before destructive ops
+3. _save_current_to(current, --move)
    ├── mv all items: ~/.claude/ → current profile dir
    ├── cp ~/.claude.json → current profile dir
    └── git commit
-3. _load_profile_to_live(new, --move)
+4. _load_profile_to_live(new, --move)
    ├── clear ~/.claude/
    ├── mv items: new profile dir → ~/.claude/
    ├── cp .claude.json → ~/.claude.json
-4. set_current(new)
+5. set_current(new)
 ```
 
 ### `save [-m msg]`
@@ -183,7 +185,7 @@ Detaches without restoring backup. Migration path for native profiles.
 2. clear_current()
 ```
 
-After this: live files are untouched, `.current` is gone. Claude Code sees normal config.
+After this: live files are untouched, `.current` is gone. Claude Code sees normal config. Re-entering later with `use`/`new` is guarded — see "Auto-save before switch" under Safety design.
 
 ## Key modules
 
@@ -206,6 +208,8 @@ All file operations. **Commands never copy/move files directly.**
 | `_seed_profile` | `new` | Copy .seed/ or defaults to profile |
 | `_snapshot_current` | `fork`, backup | cp ~/.claude/ + ~/.claude.json to dst |
 | `_save_current_to` | `use`, `save`, `deactivate` | cp/mv ~/.claude/ to dst + git commit |
+| `_live_state_nonempty` | `use`, `new` (guard) | Anything unsaved to lose in the live state? |
+| `_live_state_equals_dir` | `use`, `new` (guard) | Byte-compare live state to a profile-shaped dir |
 | `_validate_profile_for_load` | `use` | Pre-check safety before destructive ops |
 | `_load_profile_to_live` | `use`, `new`, `restore` | cp/mv profile to ~/.claude/ |
 | `_restore_from_backup` | `deactivate` | Load from .pre-profiles-backup |
@@ -232,9 +236,10 @@ Git operations for version history:
 Core operations: `new`, `fork`, `use`, `save`, `deactivate`. All follow the same pattern:
 1. Validate input
 2. Ensure backup exists
-3. Auto-save current profile if needed
-4. Perform the operation
-5. Update `.current`
+3. Guard: refuse if unsaved live state would be wiped (`use`/`new`)
+4. Auto-save current profile if needed
+5. Perform the operation
+6. Update `.current`
 
 ### `commands/ui.sh`
 
@@ -249,6 +254,8 @@ Created once by `_backup_raw_state()` on first `fork` or `new`. Never modified a
 ### Auto-save before switch
 
 Every operation that changes the active profile (`use`, `new`, `deactivate`) saves the current profile first. The user never loses unsaved changes.
+
+When nothing would auto-save the live state — no profile is current (detached after `deactivate`), or `.current` names a profile dir that no longer exists — `use` and `new` refuse instead of wiping it (`_guard_detached_live_state` in `commands/profile.sh`). They proceed only with `--force`, when the live state is empty, when it is byte-identical to the original backup, or when the backup was created by that very command (first run — the fresh backup captures the live state). `fork <name>` is the rescue path: it preserves the detached live state as a profile and re-attaches.
 
 ### Pre-validation before destructive switch
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -37,7 +37,15 @@ After running it:
 
 ## If you change your mind
 
-While detached, nothing auto-saves your live config. If you run `claude-profile use` or `new` again, they refuse rather than silently overwrite anything you changed since detaching. Run `claude-profile fork <name>` to save your current config as a new profile (this re-attaches you), or re-run with `--force` to discard the detached changes.
+While detached, nothing auto-saves your live config, so `use` and `new` stop and ask you to decide:
+
+```bash
+# Keep what you have now — save it as a new profile (this re-attaches you)
+claude-profile fork back-from-native
+
+# Or switch anyway, discarding what changed while detached
+claude-profile use work --force
+```
 
 ## What `deactivate` (without --keep) does
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -35,6 +35,10 @@ After running it:
 - `~/.claude.json` — your current profile's MCP servers (unchanged)
 - `~/.local/share/claude-profile/` — all saved profiles (can be deleted or kept for reference)
 
+## If you change your mind
+
+While detached, nothing auto-saves your live config. If you run `claude-profile use` or `new` again, they refuse rather than silently overwrite anything you changed since detaching. Run `claude-profile fork <name>` to save your current config as a new profile (this re-attaches you), or re-run with `--force` to discard the detached changes.
+
 ## What `deactivate` (without --keep) does
 
 Restores the backup taken when you first ran `fork` or `new`. Use this if you want to go back to your original config from before you started using profiles.

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -16,6 +16,69 @@ _skip_entry() {
   esac
 }
 
+# True (0) when the live state holds anything a load would destroy:
+# ~/.claude.json exists, or live ~/.claude/ contains any entry (dotfiles
+# included) other than the skipped git metadata.
+_live_state_nonempty() {
+  if [[ -e "$HOME/.claude.json" ]]; then
+    return 0
+  fi
+  local f
+  for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
+    local base
+    base="$(basename "$f")"
+    if _skip_entry "$base"; then
+      continue
+    fi
+    if [[ -L "$f" || -e "$f" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# True (0) when the live state is byte-identical to a profile-shaped directory
+# (live ~/.claude/ entries minus skipped git metadata, plus ~/.claude.json as
+# the directory's .claude.json). A live state that already exists elsewhere is
+# safe to replace.
+_live_state_equals_dir() {
+  local dir="$1"
+  local f base
+  # Every live entry must have an identical counterpart in $dir
+  for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
+    base="$(basename "$f")"
+    if _skip_entry "$base"; then
+      continue
+    fi
+    if [[ ! -L "$f" && ! -e "$f" ]]; then
+      continue
+    fi
+    if ! diff -rq "$f" "$dir/$base" >/dev/null 2>&1; then
+      return 1
+    fi
+  done
+  # Entries only in $dir mean the live state lost something — not identical
+  for f in "$dir"/* "$dir"/.*; do
+    base="$(basename "$f")"
+    if _skip_entry "$base" || [[ "$base" == ".claude.json" ]]; then
+      continue
+    fi
+    if [[ ! -L "$f" && ! -e "$f" ]]; then
+      continue
+    fi
+    if [[ ! -e "$CLAUDE_DIR/$base" ]]; then
+      return 1
+    fi
+  done
+  # Special: ~/.claude.json lives outside CLAUDE_DIR — compare it explicitly
+  if [[ -e "$HOME/.claude.json" || -e "$dir/.claude.json" ]]; then
+    if ! diff -q "$HOME/.claude.json" "$dir/.claude.json" >/dev/null 2>&1; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
 # Seed a new (empty) profile with template files.
 # Uses $PROFILES_DIR/.seed/ if it exists, otherwise falls back to built-in defaults.
 _seed_profile() {

--- a/tests/data_safety.bats
+++ b/tests/data_safety.bats
@@ -125,6 +125,215 @@ load test_helper
   ! grep -q "server-b" "$HOME/.claude.json"
 }
 
+# ─── Detached live state is never silently destroyed ─────
+# After `deactivate` / `deactivate --keep` no profile is current, so the
+# auto-save in use/new is skipped. Config created while detached must not
+# be wiped: use/new must refuse (pointing at `fork` and `--force`) unless
+# --force is given or there is nothing in the live state to lose.
+
+@test "use: refuses to overwrite detached live state after deactivate --keep" {
+  run_cli_ok fork keeper
+  run_cli_ok fork target
+  run_cli_ok use keeper
+  run_cli_ok deactivate --keep
+
+  # Config created while detached — no profile will auto-save it
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  echo '{"mcpServers": {"precious-server": {"type": "http"}}}' > "$HOME/.claude.json"
+
+  run_cli use target
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"fork"* ]]
+  [[ "$output" == *"--force"* ]]
+
+  # Live state must be completely untouched
+  [ -f "$CLAUDE_CODE_HOME/skills/precious/SKILL.md" ]
+  grep -q "irreplaceable" "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  grep -q "precious-server" "$HOME/.claude.json"
+}
+
+@test "use --force: discards detached live state and switches" {
+  run_cli_ok fork keeper
+  run_cli_ok fork target
+  # target is active after fork — give it a distinctive marker
+  echo '{"target_marker": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok use keeper
+  run_cli_ok deactivate --keep
+
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  echo '{"mcpServers": {"precious-server": {"type": "http"}}}' > "$HOME/.claude.json"
+
+  run_cli_ok use --force target
+
+  # target's content is live; the detached data was knowingly discarded
+  grep -q '"target_marker"' "$CLAUDE_CODE_HOME/settings.json"
+  [ ! -f "$CLAUDE_CODE_HOME/skills/precious/SKILL.md" ]
+  ! grep -q "precious-server" "$HOME/.claude.json"
+}
+
+@test "use: refuses to overwrite detached live state after regular deactivate" {
+  run_cli_ok fork myprofile
+  run_cli_ok use myprofile
+  run_cli_ok deactivate
+
+  # New config created on top of the restored original
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  echo '{"mcpServers": {"precious-server": {"type": "http"}}}' > "$HOME/.claude.json"
+
+  run_cli use myprofile
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"fork"* ]]
+  [[ "$output" == *"--force"* ]]
+  [ -f "$CLAUDE_CODE_HOME/skills/precious/SKILL.md" ]
+  grep -q "irreplaceable" "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  grep -q "precious-server" "$HOME/.claude.json"
+}
+
+@test "new: refuses to overwrite detached live state" {
+  run_cli_ok fork myprofile
+  run_cli_ok deactivate --keep
+
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  echo '{"mcpServers": {"precious-server": {"type": "http"}}}' > "$HOME/.claude.json"
+
+  run_cli new fresh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"fork"* ]]
+  [[ "$output" == *"--force"* ]]
+  [ -f "$CLAUDE_CODE_HOME/skills/precious/SKILL.md" ]
+  grep -q "irreplaceable" "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  grep -q "precious-server" "$HOME/.claude.json"
+}
+
+@test "new --force: discards detached live state and activates seeded profile" {
+  run_cli_ok fork myprofile
+  run_cli_ok deactivate --keep
+
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  echo '{"mcpServers": {"precious-server": {"type": "http"}}}' > "$HOME/.claude.json"
+
+  run_cli_ok new --force fresh
+
+  # Seeded clean config is live; the detached data was knowingly discarded
+  [ -f "$CLAUDE_CODE_HOME/settings.json" ]
+  [[ "$(cat "$HOME/.claude.json")" == "{}" ]]
+  [ ! -f "$CLAUDE_CODE_HOME/skills/precious/SKILL.md" ]
+}
+
+@test "fork rescues detached live state, then plain use preserves it in the rescue profile" {
+  run_cli_ok fork original
+  run_cli_ok deactivate --keep
+
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+  echo '{"mcpServers": {"precious-server": {"type": "http"}}}' > "$HOME/.claude.json"
+
+  # fork is the advertised rescue path: it captures live state AND re-attaches
+  run_cli_ok fork rescued
+  # ...so a plain switch needs no --force and auto-saves into the rescue profile
+  run_cli_ok use original
+
+  [ -f "$(profile_dir rescued)/skills/precious/SKILL.md" ]
+  grep -q "irreplaceable" "$(profile_dir rescued)/skills/precious/SKILL.md"
+  grep -q "precious-server" "$(profile_dir rescued)/.claude.json"
+}
+
+@test "use: proceeds without --force when detached live state is empty" {
+  run_cli_ok fork myprofile
+  run_cli_ok deactivate --keep
+
+  # Nothing to lose: no ~/.claude.json, ~/.claude/ has only .git/.gitignore
+  rm -f "$HOME/.claude.json"
+  find "$CLAUDE_CODE_HOME" -mindepth 1 -maxdepth 1 \
+    ! -name .git ! -name .gitignore -exec rm -rf {} +
+
+  run_cli_ok use myprofile
+  grep -q '"effortLevel"' "$CLAUDE_CODE_HOME/settings.json"
+}
+
+# A valid .current can also point at a profile dir that no longer exists
+# (removed manually or lost in a sync). The auto-save silently does nothing
+# then — exactly like the detached case, so the same guard must apply.
+
+@test "use: refuses when .current names a missing profile dir" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+  run_cli_ok use alpha
+  rm -rf "$(profile_dir alpha)"
+
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+
+  run_cli use beta
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--force"* ]]
+  [ -f "$CLAUDE_CODE_HOME/skills/precious/SKILL.md" ]
+  grep -q "github" "$HOME/.claude.json"
+}
+
+@test "new: refuses when .current names a missing profile dir" {
+  run_cli_ok fork alpha
+  rm -rf "$(profile_dir alpha)"
+
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+
+  run_cli new fresh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--force"* ]]
+  [ -f "$CLAUDE_CODE_HOME/skills/precious/SKILL.md" ]
+}
+
+@test "use --force: proceeds when .current names a missing profile dir" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+  run_cli_ok use alpha
+  rm -rf "$(profile_dir alpha)"
+
+  mkdir -p "$CLAUDE_CODE_HOME/skills/precious"
+  echo "irreplaceable" > "$CLAUDE_CODE_HOME/skills/precious/SKILL.md"
+
+  run_cli_ok use --force beta
+  [ ! -f "$CLAUDE_CODE_HOME/skills/precious/SKILL.md" ]
+  grep -q '"effortLevel"' "$CLAUDE_CODE_HOME/settings.json"
+}
+
+@test "use --force: still auto-saves when a profile is active" {
+  run_cli_ok fork keeper
+  run_cli_ok fork target
+  run_cli_ok use keeper
+  echo '{"keeper_change": true}' > "$CLAUDE_CODE_HOME/settings.json"
+
+  # --force only bypasses the detached guard — never the auto-save
+  run_cli_ok use --force target
+  grep -q '"keeper_change"' "$(profile_dir keeper)/settings.json"
+}
+
+@test "use: proceeds without --force when detached live equals the backup" {
+  run_cli_ok fork myprofile
+  run_cli_ok deactivate --keep
+
+  # Nothing changed since first activation: live == original backup,
+  # so a load destroys nothing the backup doesn't already preserve.
+  run_cli_ok use myprofile
+}
+
+@test "use: refuses when detached live differs from backup by one modified file" {
+  run_cli_ok fork myprofile
+  run_cli_ok deactivate --keep
+  echo '{"tweaked": true}' > "$CLAUDE_CODE_HOME/settings.json"
+
+  run_cli use myprofile
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--force"* ]]
+  grep -q '"tweaked"' "$CLAUDE_CODE_HOME/settings.json"
+}
+
 # ─── Directory contents preserved through cycles ─────────
 
 @test "skills directory contents survive fork-use-save-switch-use cycle" {


### PR DESCRIPTION
## The bug

`use` and `new` only auto-save the outgoing live state when a profile is current:

```sh
if [[ -n "$current" && -d "$PROFILES_DIR/$current" ]]; then
  _save_current_to "$PROFILES_DIR/$current" ... --move
fi
```

After `deactivate` or `deactivate --keep`, `.current` is cleared, so the save is skipped — but execution still reached `_load_profile_to_live`, which clears `~/.claude/` and deletes `~/.claude.json`. Everything created while detached was destroyed with no copy anywhere: the old profile holds only the deactivation-time snapshot, and `.pre-profiles-backup` is written once and never refreshed.

The sequence is ordinary: `deactivate --keep` (the documented migration path), keep working in Claude Code — new MCP servers, skills, agents — change your mind, `use <profile>`. Everything accumulated in between is gone. This is the exact data-loss class CLAUDE.md documents from early development, and it contradicted the README's "no changes are lost" guarantee.

The same gap opens when `.current` names a profile whose directory no longer exists (removed manually, lost in a sync): the name passes validation, the `-d` check above silently skips the save, and the load wipes live state anyway.

## The fix

`use` and `new` refuse when the auto-save would not run and something would actually be lost. The guard fires only when all of these hold:

- no current profile, or `.current` names a missing profile dir — mirroring the auto-save condition exactly
- `.pre-profiles-backup` already existed when the command started (a backup created by the command itself captures the live state, so first runs keep working with zero friction)
- the live state is non-empty
- the live state is not byte-identical to the backup (keeps `save` as a first command followed by `use` working)
- `--force` was not passed

The error names the two ways out: `fork <name>` preserves the live state as a new profile and re-attaches; `--force` discards it deliberately. `--force` bypasses only this guard — target pre-validation and the normal auto-save still run. Refusal happens before any destructive operation and has no side effects.

The equality check (`_live_state_equals_dir`) fails closed: any diff error, missing counterpart, or entry present on only one side counts as "not equal" and refuses. A false refusal costs a `--force`; there is no path to a false "safe to wipe".

## Tests

Written first, red→green. 13 new tests in `data_safety.bats`:

- refusal with live state untouched: after `deactivate --keep`, after regular `deactivate`, and with a dangling `.current` — for both `use` and `new`
- `--force` proceeds in each of those states; with a profile attached it still auto-saves (pinned so a refactor cannot conflate "force" with "skip saving")
- the `fork` rescue path: detached data lands in the rescue profile and survives the next switch
- exemption boundaries: empty live state and byte-identical-to-backup proceed without `--force`; a single modified file refuses

Full suite: 216 tests, 0 failures.

Also adds `--force` to the help text and both shell completions, and documents the guard in the README safety section.