### PR TITLE
Document trust and safe install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Define each as a profile, switch with one command.
 
 ---
 
+## Trust and safe install
+
+`claude-profile` is intentionally small and transparent. It is a plain Bash CLI with no npm package, Python package, vendored binary, background service, or runtime network call. The installed tool uses Bash, Git for profile history, and standard Unix tools like `cp`, `mv`, `find`, `diff`, `sed`, and `tar`.
+
+The source is the product: you can read the entrypoint, `lib/`, `commands/`, and install scripts before installing, or ask any code review tool to inspect them. For the most cautious path, clone the repository, review the source, then run `bash install.sh` from that reviewed checkout.
+
 > **This tool manages global (user-level) profiles** — it switches your entire `~/.claude/` directory and `~/.claude.json`.
 > If you need **project-level profiles** (per-repo settings), see [claude-project-profile](https://github.com/yarikleto/claude-project-profile).
 


### PR DESCRIPTION
## Summary

Adds a short top-of-README section explaining why `claude-profile` is reviewable before install:

- plain Bash CLI
- no npm or Python package dependency
- no vendored binary, background service, or runtime network call
- source-first review path before running `bash install.sh`

## Impact

Gives cautious users a clearer reason to trust the CLI without asking them to run developer-oriented tests or audit commands.

## Validation

- `git diff --check -- README.md`
- pre-push hook ran `bats tests/` and passed all 216 tests
