### PR TITLE
Add CLI version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <br>
 
 [![Tests](https://github.com/yarikleto/claude-profile/actions/workflows/tests.yml/badge.svg)](https://github.com/yarikleto/claude-profile/actions/workflows/tests.yml)
+[![CLI version](https://img.shields.io/github/v/release/yarikleto/claude-profile?label=CLI&color=18182f)](https://github.com/yarikleto/claude-profile/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Shell: Bash](https://img.shields.io/badge/Shell-Bash-4EAA25?logo=gnubash&logoColor=white)](claude-profile)
 [![Tests: bats](https://img.shields.io/badge/Tests-bats--core-yellow)](tests/)


### PR DESCRIPTION
## Summary

Adds a dynamic CLI version badge to the README header. The badge reads the latest GitHub release through Shields and links to the repository's latest release page.

## Why

A hard-coded README badge can drift when `VERSION` changes. Using the GitHub release badge keeps the displayed CLI version aligned with published releases without another manual update step.

## Impact

Documentation-only change. No runtime behavior changes.

## Validation

- Verified the Shields badge endpoint returns `200` as an SVG.
- Pre-push hook ran `bats tests/`: 216/216 passing.
