### PR TITLE
Simplify deactivate flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ completions/
 - **All file operations go through `lib/files.sh`**. Never copy/remove files directly in command files — use `_snapshot_current`, `_save_current_to`, `_load_profile_to_live`, `_restore_from_backup`, `_seed_profile`.
 - **All git operations go through `lib/git.sh`**. Never call `git` directly in command files — use `_git_init`, `_git_commit`, `_git_resolve_ref`.
 - **Profiles are independent copies, not symlinks**. Switching copies/moves the entire `~/.claude/` directory.
-- **The original backup (`.pre-profiles-backup/`) is never modified** after creation. It's the safety net.
+- **The original backup (`.pre-profiles-backup/`) is never overwritten or deleted by normal profile operations** after creation. It's the safety net.
 - **Profiles are stored in XDG-compliant location** (`~/.local/share/claude-profile/`), separate from `~/.claude/`.
 - **`~/.claude.json`** lives in `$HOME`, not inside `~/.claude/`. It is stored as `.claude.json` inside profile directories.
 - **The top-level `VERSION` file is the version source of truth**. `lib/config.sh` reads it at runtime; installers and Homebrew formulas must ship it with the runtime files.
@@ -75,9 +75,9 @@ Priority: `CLAUDE_PROFILE_HOME` > `XDG_DATA_HOME/claude-profile` > `$HOME/.local
 
 `new` creates profiles seeded from `.seed/` (user-editable). Falls back to built-in defaults in `SEED_NAMES`/`SEED_CONTENTS` (config.sh) if `.seed/` doesn't exist. `install.sh` creates `.seed/` with defaults.
 
-### deactivate --keep
+### deactivate / deactivate --keep
 
-`deactivate --keep` detaches from profiles without restoring the backup — the user's current config stays as-is. This is the migration path for when native profiles arrive. Regular `deactivate` restores from `.pre-profiles-backup/`. While detached, `use`/`new` refuse to overwrite a live config that isn't saved in any profile — `fork` preserves it, `--force` discards it.
+`deactivate --keep` detaches from profiles without restoring the backup — the user's current config stays as-is. This is the migration path for when native profiles arrive. Regular `deactivate` restores from `.pre-profiles-backup/`; it also works while detached (after `--keep`) — if the live config is non-empty, differs from the backup, and isn't saved in any profile, it is first preserved as a generated `detached-<timestamp>` profile. While detached, `use`/`new` refuse to overwrite a live config that isn't saved in any profile — `fork` preserves it, `--force` discards it.
 
 ## Development workflow — TDD
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ claude-profile use experiment     # clean slate
 claude-profile use default        # back to your setup
 ```
 
-That's it. Your original config is automatically backed up and can be restored at any time with `claude-profile deactivate`.
+That's it. Your original config is automatically backed up and can be restored with `claude-profile deactivate`.
 
 ## What gets switched
 
@@ -141,7 +141,9 @@ claude-profile deactivate         # restore your original pre-profiles config
 claude-profile deactivate --keep  # detach, keep the current profile's files live
 ```
 
-Both save the active profile first. `deactivate` returns you to the config you had before you first ran `fork`/`new`. `--keep` leaves your files exactly as they are — Claude Code sees a normal config, and your profiles stay saved on disk. This is the path for [migrating to native profiles](#migrating-to-native-claude-code-profiles), or for pausing the tool without changing anything.
+Both are safe. `deactivate` returns you to the config you had before you first ran `fork`/`new`. If you already detached with `--keep`, running `deactivate` later still restores the original backup; if your detached live config has changed, it is first saved as a generated `detached-...` profile.
+
+`deactivate --keep` leaves your files exactly as they are — Claude Code sees a normal config, and your profiles stay saved on disk. This is the path for [migrating to native profiles](#migrating-to-native-claude-code-profiles), or for pausing the tool without changing anything.
 
 While detached, nothing auto-saves your changes — so if your live config isn't saved in any profile, `use` and `new` stop and ask you to decide:
 
@@ -182,13 +184,13 @@ This is configured during installation. If you already have a custom `statusLine
 
 ## Safety
 
-- **Original backup** — your pre-profiles config is backed up on first use and **never modified** by any operation. It's your safety net.
+- **Original backup** — your pre-profiles config is backed up once on first use. Normal profile operations do not overwrite or delete it, so it remains the safety net while the profiles data directory exists.
 - **Auto-save on switch** — `use` saves the current profile before switching. No changes are lost.
 - **No silent overwrite when unsaved** — when no profile would auto-save your live config (after `deactivate`, or if the active profile's directory is missing), `use` and `new` refuse to wipe it. Run `claude-profile fork <name>` to preserve it as a profile, or re-run with `--force` to discard it.
 - **Full isolation** — each profile is an independent copy. Changing one never affects another.
 - **Clean exit** — `deactivate` restores your original state. `deactivate --keep` keeps your current config for [migration](#migrating-to-native-claude-code-profiles).
 
-> **Your original backup is always safe.** It lives at `~/.local/share/claude-profile/.pre-profiles-backup/` and is never modified — not by `--keep`, not by regular `deactivate`, not by any profile operation. You can always restore from it manually.
+> **Your original backup is preserved by normal profile operations.** It lives at `$CLAUDE_PROFILE_HOME/.pre-profiles-backup/` when `CLAUDE_PROFILE_HOME` is set, otherwise `$XDG_DATA_HOME/claude-profile/.pre-profiles-backup/` when `XDG_DATA_HOME` is set, otherwise `~/.local/share/claude-profile/.pre-profiles-backup/`. `deactivate --keep` does not restore it; `deactivate` restores from it and refuses to proceed if it is missing while a profile is active. You can restore from it manually while that directory still exists and is readable.
 
 ## Migrating to native Claude Code profiles
 
@@ -209,6 +211,8 @@ rm -rf ~/.local/share/claude-profile
 ```
 
 `--keep` saves your profile, clears the active marker, and leaves all your files in place — Claude Code sees normal config. Without `--keep`, `deactivate` restores your original pre-profiles config.
+
+If you detach with `--keep` and later decide to go back to the original pre-profiles config, run `claude-profile deactivate`. If your detached live config changed, it is saved first as a generated `detached-...` profile.
 
 While detached, your live config isn't saved in any profile — so if you change your mind and run `use` or `new`, they refuse rather than overwrite it. `fork <name>` re-attaches and preserves it; `--force` discards it.
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This is configured during installation. If you already have a custom `statusLine
 - **Full isolation** — each profile is an independent copy. Changing one never affects another.
 - **Clean exit** — `deactivate` restores your original state. `deactivate --keep` keeps your current config for [migration](#migrating-to-native-claude-code-profiles).
 
-> **Your original backup is preserved by normal profile operations.** It lives at `$CLAUDE_PROFILE_HOME/.pre-profiles-backup/` when `CLAUDE_PROFILE_HOME` is set, otherwise `$XDG_DATA_HOME/claude-profile/.pre-profiles-backup/` when `XDG_DATA_HOME` is set, otherwise `~/.local/share/claude-profile/.pre-profiles-backup/`. `deactivate --keep` does not restore it; `deactivate` restores from it and refuses to proceed if it is missing while a profile is active. You can restore from it manually while that directory still exists and is readable.
+> **Your original backup is preserved by normal profile operations.** It lives at `$CLAUDE_PROFILE_HOME/.pre-profiles-backup/` when `CLAUDE_PROFILE_HOME` is set, otherwise `$XDG_DATA_HOME/claude-profile/.pre-profiles-backup/` when `XDG_DATA_HOME` is set, otherwise `~/.local/share/claude-profile/.pre-profiles-backup/`. `deactivate --keep` does not restore it; `deactivate` restores from it and refuses to proceed if it is missing. You can restore from it manually while that directory still exists and is readable.
 
 ## Migrating to native Claude Code profiles
 

--- a/commands/profile.sh
+++ b/commands/profile.sh
@@ -215,6 +215,18 @@ _live_state_saved_in_any_profile() {
   return 1
 }
 
+_any_profiles_exist() {
+  local dir base
+  for dir in "$PROFILES_DIR"/*; do
+    base="$(basename "$dir")"
+    if [[ "$base" == .* || ! -d "$dir" ]]; then
+      continue
+    fi
+    return 0
+  done
+  return 1
+}
+
 cmd_deactivate() {
   local keep=false
   while [[ $# -gt 0 ]]; do
@@ -247,12 +259,15 @@ cmd_deactivate() {
   else
     # Verify backup exists before doing destructive save
     if [[ ! -d "$backup_dir" ]]; then
-      if [[ -z "$current" ]]; then
-        warn "No profile is active"; return
-      else
+      if [[ -n "$current" ]]; then
         err "Original backup not found — refusing to restore (would destroy live files)"
         return 1
       fi
+      if _any_profiles_exist; then
+        err "Original backup not found — nothing to restore"
+        return 1
+      fi
+      warn "No profile is active"; return
     fi
 
     if [[ -n "$current" ]]; then

--- a/commands/profile.sh
+++ b/commands/profile.sh
@@ -185,19 +185,59 @@ cmd_save() {
   ok "Saved $(_pname "$name")"
 }
 
+_deactivate_usage() {
+  err "Usage: claude-profile deactivate [--keep]"
+}
+
+_next_detached_profile_name() {
+  local base name i
+  base="detached-$(date +%Y%m%d-%H%M%S)"
+  name="$base"
+  i=2
+  while [[ -d "$PROFILES_DIR/$name" ]]; do
+    name="$base-$i"
+    i=$((i + 1))
+  done
+  echo "$name"
+}
+
+_live_state_saved_in_any_profile() {
+  local dir base
+  for dir in "$PROFILES_DIR"/*; do
+    base="$(basename "$dir")"
+    if [[ "$base" == .* || ! -d "$dir" ]]; then
+      continue
+    fi
+    if _live_state_equals_dir "$dir"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 cmd_deactivate() {
   local keep=false
-  if [[ "${1:-}" == "--keep" ]]; then
-    keep=true
-  fi
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --keep)
+        keep=true
+        shift
+        ;;
+      *)
+        _deactivate_usage
+        return 1
+        ;;
+    esac
+  done
 
   local current
   current="$(get_current_validated)"
-  if [[ -z "$current" ]]; then
-    warn "No profile is active"; return
-  fi
+  local backup_dir="$PROFILES_DIR/.pre-profiles-backup"
 
   if [[ "$keep" == true ]]; then
+    if [[ -z "$current" ]]; then
+      warn "No profile is active"; return
+    fi
     # Keep current files in place — save a copy to profile, then detach
     info "Saving $(_pname "$current")..."
     _save_current_to "$PROFILES_DIR/$current" "Auto-save before deactivate --keep"
@@ -206,16 +246,35 @@ cmd_deactivate() {
     info "You can safely remove ${BOLD}$PROFILES_DIR${NC} when ready"
   else
     # Verify backup exists before doing destructive save
-    local backup_dir="$PROFILES_DIR/.pre-profiles-backup"
     if [[ ! -d "$backup_dir" ]]; then
-      err "Original backup not found — refusing to restore (would destroy live files)"
-      return 1
+      if [[ -z "$current" ]]; then
+        warn "No profile is active"; return
+      else
+        err "Original backup not found — refusing to restore (would destroy live files)"
+        return 1
+      fi
     fi
-    info "Saving $(_pname "$current")..."
-    _save_current_to "$PROFILES_DIR/$current" "Auto-save before deactivate" --move
+
+    if [[ -n "$current" ]]; then
+      info "Saving $(_pname "$current")..."
+      _save_current_to "$PROFILES_DIR/$current" "Auto-save before deactivate" --move
+    elif _live_state_nonempty && ! _live_state_equals_dir "$backup_dir" && ! _live_state_saved_in_any_profile; then
+      local detached_name detached_dir
+      detached_name="$(_next_detached_profile_name)"
+      detached_dir="$PROFILES_DIR/$detached_name"
+      mkdir -p "$detached_dir"
+      info "Saving detached config as $(_pname "$detached_name")..."
+      _snapshot_current "$detached_dir"
+      _git_init "$detached_dir"
+    fi
+
     info "Restoring original state..."
     _restore_from_backup
     clear_current
-    ok "Deactivated $(_pname "$current"), restored original state"
+    if [[ -n "$current" ]]; then
+      ok "Deactivated $(_pname "$current"), restored original state"
+    else
+      ok "Restored original state"
+    fi
   fi
 }

--- a/completions/claude-profile.bash
+++ b/completions/claude-profile.bash
@@ -49,6 +49,11 @@ _claude_profile_completions() {
     fork)
       COMPREPLY=()  # free-form name
       ;;
+    deactivate|off)
+      if [[ "$cur" == -* || ${COMP_CWORD} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "--keep" -- "$cur"))
+      fi
+      ;;
     statusline)
       if [[ ${COMP_CWORD} -eq 2 ]]; then
         COMPREPLY=($(compgen -W "install uninstall" -- "$cur"))

--- a/completions/claude-profile.zsh
+++ b/completions/claude-profile.zsh
@@ -58,6 +58,12 @@ _claude-profile() {
       fork)
         _message 'profile name'
         ;;
+      deactivate|off)
+        local -a flags=(
+          '--keep:Detach without restoring backup'
+        )
+        _describe 'option' flags
+        ;;
       statusline)
         local -a actions=('install:Install status line script' 'uninstall:Remove status line script')
         _describe 'action' actions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,7 +173,8 @@ Restores original state from backup.
 1. Verify backup exists
 2. If a profile is active:
    └── _save_current_to(current, --move)       ← save profile one last time
-3. If detached live state differs from backup:
+3. If detached live state is non-empty, differs from the backup,
+   and isn't saved in any profile:
    └── _snapshot_current(detached-...) + _git_init(detached-...)
 4. _restore_from_backup()                      ← cp from .pre-profiles-backup to live
 5. clear_current()
@@ -209,10 +210,10 @@ All file operations. **Commands never copy/move files directly.**
 | Function | Used by | Behavior |
 |----------|---------|----------|
 | `_seed_profile` | `new` | Copy .seed/ or defaults to profile |
-| `_snapshot_current` | `fork`, backup | cp ~/.claude/ + ~/.claude.json to dst |
+| `_snapshot_current` | `fork`, `deactivate`, backup | cp ~/.claude/ + ~/.claude.json to dst |
 | `_save_current_to` | `use`, `save`, `deactivate` | cp/mv ~/.claude/ to dst + git commit |
-| `_live_state_nonempty` | `use`, `new` (guard) | Anything unsaved to lose in the live state? |
-| `_live_state_equals_dir` | `use`, `new` (guard) | Byte-compare live state to a profile-shaped dir |
+| `_live_state_nonempty` | `use`, `new` (guard), `deactivate` | Anything unsaved to lose in the live state? |
+| `_live_state_equals_dir` | `use`, `new` (guard), `deactivate` | Byte-compare live state to a profile-shaped dir |
 | `_validate_profile_for_load` | `use` | Pre-check safety before destructive ops |
 | `_load_profile_to_live` | `use`, `new`, `restore` | cp/mv profile to ~/.claude/ |
 | `_restore_from_backup` | `deactivate` | Load from .pre-profiles-backup |
@@ -268,7 +269,7 @@ When nothing would auto-save the live state — no profile is current (detached 
 
 - `_load_profile_to_live` skips symlinks in profile dirs (`! -L` check)
 - `_validate_profile_for_load` rejects nested symlinks inside directories
-- `_snapshot_current` follows symlinks at the source (user's live files are trusted) via `cp -RH`
+- `_snapshot_current` follows symlinks at the source (user's live files are trusted) via `cp -RL`
 - Profile name validation rejects `..`, `/`, leading `.` or `-`
 
 ## Testing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ Profiles are stored in an XDG-compliant location, separate from `~/.claude/`:
 ├── .seed/                                  # templates for `new` (user-editable)
 │   ├── settings.json
 │   └── .claude.json
-├── .pre-profiles-backup/                   # original state, NEVER modified
+├── .pre-profiles-backup/                   # original state backup
 │   ├── settings.json
 │   ├── CLAUDE.md
 │   ├── projects/
@@ -171,9 +171,12 @@ Restores original state from backup.
 
 ```
 1. Verify backup exists
-2. _save_current_to(current, --move)    ← save profile one last time
-3. _restore_from_backup()               ← cp from .pre-profiles-backup to live
-4. clear_current()
+2. If a profile is active:
+   └── _save_current_to(current, --move)       ← save profile one last time
+3. If detached live state differs from backup:
+   └── _snapshot_current(detached-...) + _git_init(detached-...)
+4. _restore_from_backup()                      ← cp from .pre-profiles-backup to live
+5. clear_current()
 ```
 
 ### `deactivate --keep`
@@ -249,13 +252,13 @@ Statusline integration. Creates `statusline.sh` which reads JSON from stdin (Cla
 
 ### Original backup
 
-Created once by `_backup_raw_state()` on first `fork` or `new`. Never modified after creation. Contains the full snapshot of `~/.claude/` + `~/.claude.json`. This is the "factory reset" — `deactivate` restores from here.
+Created once by `_backup_raw_state()` on first `fork` or `new`. Normal profile operations do not overwrite or delete it. Contains the full snapshot of `~/.claude/` + `~/.claude.json`. This is the "factory reset" — `deactivate` restores from here.
 
 ### Auto-save before switch
 
 Every operation that changes the active profile (`use`, `new`, `deactivate`) saves the current profile first. The user never loses unsaved changes.
 
-When nothing would auto-save the live state — no profile is current (detached after `deactivate`), or `.current` names a profile dir that no longer exists — `use` and `new` refuse to proceed (`_guard_detached_live_state` in `commands/profile.sh`). They go ahead only with `--force`, when the live state is empty, when it is byte-identical to the original backup, or when the backup was created by that very command (first run — the fresh backup captures the live state). `fork <name>` preserves a detached live state as a profile and re-attaches.
+When nothing would auto-save the live state — no profile is current (detached after `deactivate`), or `.current` names a profile dir that no longer exists — `use` and `new` refuse to proceed (`_guard_detached_live_state` in `commands/profile.sh`). They go ahead only with `--force`, when the live state is empty, when it is byte-identical to the original backup, or when the backup was created by that very command (first run — the fresh backup captures the live state). `fork <name>` preserves a detached live state as a profile and re-attaches. Plain `deactivate` preserves detached live state automatically as a generated `detached-...` profile before restoring the original backup.
 
 ### Pre-validation before destructive switch
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 ## How it works
 
-Think of it like git branches. Your original `~/.claude/` state is the **main branch** — always preserved, never modified. Each profile is an independent **fork** you can change freely.
+Think of it like git branches. Your original `~/.claude/` state is the **main branch** — backed up once and preserved by normal profile operations. Each profile is an independent **fork** you can change freely.
 
 ```
 ~/.claude/                                  ← "live" location, what Claude Code reads
@@ -16,7 +16,7 @@ Think of it like git branches. Your original `~/.claude/` state is the **main br
 ├── .current                                # tracks which profile is active
 ├── .seed/                                  # templates for `new` (user-editable)
 ├── statusline.sh                           # statusline script
-├── .pre-profiles-backup/                   # your original state (read-only)
+├── .pre-profiles-backup/                   # your original state backup
 ├── default/                                # profile with its own git history
 │   ├── .git/
 │   ├── settings.json

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,7 +26,7 @@ After this, your `~/.claude/` will look exactly as if you'd configured it manual
 2. **Clears** the active profile marker (`.current` file)
 3. **Does NOT** restore the original backup — your current config stays
 
-> **Your original backup is safe.** Neither `--keep` nor regular `deactivate` ever modifies the backup at `~/.local/share/claude-profile/.pre-profiles-backup/`. It is created once and never touched. You can always restore from it manually, even after migration.
+> **Your original backup is preserved by normal profile operations.** It lives at `$CLAUDE_PROFILE_HOME/.pre-profiles-backup/` when `CLAUDE_PROFILE_HOME` is set, otherwise `$XDG_DATA_HOME/claude-profile/.pre-profiles-backup/` when `XDG_DATA_HOME` is set, otherwise `~/.local/share/claude-profile/.pre-profiles-backup/`. You can restore from it while that directory still exists and is readable.
 
 After running it:
 - `~/.claude/settings.json` — your current profile's settings (unchanged)
@@ -37,7 +37,17 @@ After running it:
 
 ## If you change your mind
 
-While detached, nothing auto-saves your live config, so `use` and `new` stop and ask you to decide:
+While detached, nothing auto-saves your live config into the profile you detached from.
+
+To go back to the original pre-profiles config:
+
+```bash
+claude-profile deactivate
+```
+
+If your detached live config changed, `deactivate` saves it first as a generated `detached-...` profile, then restores the original backup.
+
+To re-attach the current live config as a named profile or switch to a saved profile:
 
 ```bash
 # Keep what you have now — save it as a new profile (this re-attaches you)

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -4,13 +4,14 @@ There are three layers to remove: your Claude Code configuration (profiles data)
 
 ## Step 1: Restore your original Claude Code configuration
 
-If you have an active profile, deactivate it to restore your original `~/.claude/` state:
+Deactivate to restore your original `~/.claude/` state:
 
 ```bash
 claude-profile deactivate
 ```
 
 This saves the active profile, copies your original files back from the backup, and clears the active profile marker.
+If you already detached with `deactivate --keep`, the same command restores the original backup; if your detached live config changed, it is first saved as a generated `detached-...` profile.
 
 **If `claude-profile` is no longer installed**, restore manually:
 

--- a/tests/completions.bats
+++ b/tests/completions.bats
@@ -74,6 +74,15 @@ _run_bash_completion() {
   [[ "$output" == *"uninstall"* ]]
 }
 
+@test "bash completion: deactivate completes keep option" {
+  _run_bash_completion deactivate ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--keep"* ]]
+  [[ "$output" != *"--restore"* ]]
+  [[ "$output" != *"--force"* ]]
+  [[ "$output" != *"--save-as"* ]]
+}
+
 @test "bash completion: works with no profiles dir yet" {
   _run_bash_completion use ""
   [ "$status" -eq 0 ]

--- a/tests/deactivate.bats
+++ b/tests/deactivate.bats
@@ -46,6 +46,19 @@ load test_helper
   [[ "$output" == *"No profile is active"* ]]
 }
 
+@test "deactivate: detached with missing backup reports it instead of claiming no profile" {
+  run_cli_ok fork default
+  run_cli_ok deactivate --keep
+  rm -rf "$(backup_dir)"
+
+  run_cli deactivate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"backup"* ]]
+  [[ "$output" != *"No profile is active"* ]]
+  # Live files untouched
+  grep -q '"effortLevel"' "$CLAUDE_CODE_HOME/settings.json"
+}
+
 @test "deactivate: rejects unknown options" {
   run_cli deactivate --restore
   [ "$status" -ne 0 ]

--- a/tests/deactivate.bats
+++ b/tests/deactivate.bats
@@ -46,6 +46,41 @@ load test_helper
   [[ "$output" == *"No profile is active"* ]]
 }
 
+@test "deactivate: rejects unknown options" {
+  run_cli deactivate --restore
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "deactivate: restores original after keep and saves detached changes" {
+  run_cli_ok fork default
+  run_cli_ok deactivate --keep
+
+  echo '{"detached": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok deactivate
+
+  grep -q '"effortLevel"' "$CLAUDE_CODE_HOME/settings.json"
+  ! grep -q '"detached"' "$CLAUDE_CODE_HOME/settings.json"
+  [ ! -f "$CLAUDE_PROFILE_HOME/.current" ]
+
+  local saved
+  saved="$(find "$CLAUDE_PROFILE_HOME" -mindepth 1 -maxdepth 1 -type d -name 'detached-*' | head -1)"
+  [ -n "$saved" ]
+  grep -q '"detached"' "$saved/settings.json"
+}
+
+@test "deactivate: after keep does not duplicate unchanged saved profile" {
+  run_cli_ok fork default
+  echo '{"saved": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok deactivate --keep
+
+  run_cli_ok deactivate
+
+  grep -q '"effortLevel"' "$CLAUDE_CODE_HOME/settings.json"
+  [ ! -f "$CLAUDE_PROFILE_HOME/.current" ]
+  [ -z "$(find "$CLAUDE_PROFILE_HOME" -mindepth 1 -maxdepth 1 -type d -name 'detached-*')" ]
+}
+
 @test "restores MCP config" {
   run_cli_ok fork default
   run_cli_ok new nomcp


### PR DESCRIPTION
## Summary

- Keep the public deactivate flow to two choices: `deactivate` and `deactivate --keep`.
- Allow plain `deactivate` to restore the original backup after a prior `--keep` detach.
- Preserve changed detached live config automatically as a generated `detached-...` profile before restoring.
- Update docs and shell completions to match the simpler flow.
- Report a missing backup honestly when deactivating while detached: if profiles exist on disk but `.pre-profiles-backup/` is gone, `deactivate` now fails with "Original backup not found — nothing to restore" instead of exiting 0 with "No profile is active". A fresh install with no profiles still gets the no-op warning.
- Sync the remaining docs with the new flow: CLAUDE.md (backup-guarantee wording, detached `deactivate` behavior) and docs/architecture.md (detached-snapshot condition, helper "Used by" table, `cp -RL`).

## Validation

- `bats tests/` — 221 tests, 0 failures (one test added for the missing-backup-while-detached case).
- Pre-push hook reran `bats tests/` successfully before pushing the branch.