### PR TITLE
Harden profile operations against data loss and hostile input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .claude
+backups/
+projects/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ completions/
 - **Mutating commands take an exclusive lock** (`$PROFILES_DIR/.lock`, with stale-lock takeover) so concurrent invocations can't interleave rm/mv on the same live files.
 - **The destructive phase of `use`/`new`/`restore`/`deactivate` is bracketed by an `.op-in-progress` marker.** After a crash mid-switch, `use` sweeps the partially moved files back into the marker's target profile before anything can auto-save them into the wrong profile; other mutating commands refuse to run until recovered. `deactivate` completes its own interrupted restore.
 - **Auto-saves are exact snapshots**: entries (and `~/.claude.json`) deleted from the live state are also removed from the profile copy, so deletions don't resurrect on the next switch. An entirely empty live state is never saved.
-- **`~/.claude.json`** lives in `$HOME`, not inside `~/.claude/`. It is stored as `.claude.json` inside profile directories.
+- **`~/.claude.json`** lives in `$HOME`, not inside `~/.claude/`. Inside a profile it is stored under the reserved name `.claude-profile-home.json`, keeping it in a namespace disjoint from the live payload — a live file literally named `~/.claude/.claude.json` is captured as the payload entry `.claude.json` without colliding with the home file. A startup migration (`.format` stamp) moves profiles written under the older flat layout.
 - **The top-level `VERSION` file is the version source of truth**. `lib/config.sh` reads it at runtime; installers and Homebrew formulas must ship it with the runtime files.
 
 ### Full-directory snapshots

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,10 @@ completions/
 - **All git operations go through `lib/git.sh`**. Never call `git` directly in command files — use `_git_init`, `_git_commit`, `_git_resolve_ref`.
 - **Profiles are independent copies, not symlinks**. Switching copies/moves the entire `~/.claude/` directory.
 - **The original backup (`.pre-profiles-backup/`) is never overwritten or deleted by normal profile operations** after creation. It's the safety net.
-- **Profiles are stored in XDG-compliant location** (`~/.local/share/claude-profile/`), separate from `~/.claude/`.
+- **Profiles are stored in XDG-compliant location** (`~/.local/share/claude-profile/`), separate from `~/.claude/`. Startup refuses a store nested inside `~/.claude/` (or the reverse) — the switch loops would destroy the store.
+- **Mutating commands take an exclusive lock** (`$PROFILES_DIR/.lock`, with stale-lock takeover) so concurrent invocations can't interleave rm/mv on the same live files.
+- **The destructive phase of `use`/`new`/`restore`/`deactivate` is bracketed by an `.op-in-progress` marker.** After a crash mid-switch, `use` sweeps the partially moved files back into the marker's target profile before anything can auto-save them into the wrong profile; other mutating commands refuse to run until recovered. `deactivate` completes its own interrupted restore.
+- **Auto-saves are exact snapshots**: entries (and `~/.claude.json`) deleted from the live state are also removed from the profile copy, so deletions don't resurrect on the next switch. An entirely empty live state is never saved.
 - **`~/.claude.json`** lives in `$HOME`, not inside `~/.claude/`. It is stored as `.claude.json` inside profile directories.
 - **The top-level `VERSION` file is the version source of truth**. `lib/config.sh` reads it at runtime; installers and Homebrew formulas must ship it with the runtime files.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The active profile name is shown in the Claude Code status line automatically:
 Opus 4.6 · profile: review
 ```
 
-This is configured during installation. If you already have a custom `statusLine` in `settings.json`, it won't be overwritten — run `claude-profile statusline install` manually to set it up.
+The `install.sh` and curl one-liner installs configure this automatically; after a Homebrew install, run `claude-profile statusline install` once. If you already have a custom `statusLine` in `settings.json`, it won't be overwritten.
 
 ## Safety
 

--- a/claude-profile
+++ b/claude-profile
@@ -3,6 +3,12 @@
 # https://github.com/yarikleto/claude-profile
 set -euo pipefail
 
+# Git exports repository-local variables (GIT_DIR, GIT_INDEX_FILE, ...) into
+# hook subprocesses. Left in place, every git call below would operate on the
+# caller's repository instead of the profile's — potentially committing
+# ~/.claude and .claude.json onto a user branch.
+unset $(git rev-parse --local-env-vars 2>/dev/null) 2>/dev/null || true
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ─── Load modules ──────────────────────────────────────────
@@ -19,6 +25,12 @@ source "$SCRIPT_DIR/commands/ui.sh"
 # ─── Dispatch ──────────────────────────────────────────────
 cmd="${1:-help}"
 shift 2>/dev/null || true
+
+# Mutating commands take an exclusive lock — concurrent invocations interleave
+# rm/mv on the same live files and can destroy the sole copy of moved data.
+case "$cmd" in
+  new|fork|use|switch|save|deactivate|off|edit|delete|rm|restore) _acquire_lock ;;
+esac
 
 case "$cmd" in
   new)            cmd_new "$@" ;;

--- a/claude-profile
+++ b/claude-profile
@@ -28,7 +28,9 @@ source "$SCRIPT_DIR/commands/ui.sh"
 
 # Bring an existing store up to the current on-disk format before any command
 # reads or writes profiles. Idempotent (runs once per upgrade via a stamp).
-_migrate_store_format
+# Best-effort: the load path tolerates the old layout, so an odd profile dir
+# that can't be migrated must not abort (and thereby brick) every command.
+_migrate_store_format || true
 
 # ─── Dispatch ──────────────────────────────────────────────
 cmd="${1:-help}"

--- a/claude-profile
+++ b/claude-profile
@@ -26,6 +26,10 @@ source "$SCRIPT_DIR/commands/info.sh"
 source "$SCRIPT_DIR/commands/history.sh"
 source "$SCRIPT_DIR/commands/ui.sh"
 
+# Bring an existing store up to the current on-disk format before any command
+# reads or writes profiles. Idempotent (runs once per upgrade via a stamp).
+_migrate_store_format
+
 # ─── Dispatch ──────────────────────────────────────────────
 cmd="${1:-help}"
 shift 2>/dev/null || true

--- a/claude-profile
+++ b/claude-profile
@@ -32,8 +32,11 @@ shift 2>/dev/null || true
 
 # Mutating commands take an exclusive lock — concurrent invocations interleave
 # rm/mv on the same live files and can destroy the sole copy of moved data.
+# statusline is included: `statusline install` writes both the store and live
+# settings.json, so it can race a switch without the lock. Locking its bare
+# usage path too is harmless.
 case "$cmd" in
-  new|fork|use|switch|save|deactivate|off|edit|delete|rm|restore) _acquire_lock ;;
+  new|fork|use|switch|save|deactivate|off|edit|delete|rm|restore|statusline) _acquire_lock ;;
 esac
 
 case "$cmd" in

--- a/claude-profile
+++ b/claude-profile
@@ -9,6 +9,10 @@ set -euo pipefail
 # ~/.claude and .claude.json onto a user branch.
 unset $(git rev-parse --local-env-vars 2>/dev/null) 2>/dev/null || true
 
+# The store holds tracked settings/MCP config — secrets. Create every store
+# dir, temp, and Git object private to the owner. Set before any file is made.
+umask 077
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ─── Load modules ──────────────────────────────────────────

--- a/commands/history.sh
+++ b/commands/history.sh
@@ -206,6 +206,10 @@ cmd_restore() {
   fi
 
   local profile_dir="$PROFILES_DIR/$name"
+  # Restore runs Git mutations (git rm -rf ., checkout) directly on this dir —
+  # gate it on the same path-safety check as the file primitives so a symlinked
+  # profile root can't point them at files outside the store.
+  _assert_profile_path_safe "$profile_dir"
   if [[ ! -d "$profile_dir/.git" ]]; then
     err "No history for profile $(_pname "$name")"; exit 1
   fi

--- a/commands/history.sh
+++ b/commands/history.sh
@@ -66,7 +66,7 @@ _snapshot_live_for_diff() {
     fi
   done
   if [[ -e "$HOME/.claude.json" ]]; then
-    cp -L "$HOME/.claude.json" "$dst/.claude.json" || return 1
+    cp -L "$HOME/.claude.json" "$(_profile_home_json "$dst")" || return 1
   fi
 }
 

--- a/commands/history.sh
+++ b/commands/history.sh
@@ -3,6 +3,7 @@
 cmd_history() {
   local name="${1:-$(get_current)}"
   _require_profile_name "$name" "claude-profile history [name]"
+  _require_profile_exists "$name"
 
   local profile_dir="$PROFILES_DIR/$name"
   if [[ ! -d "$profile_dir/.git" ]]; then
@@ -16,13 +17,23 @@ cmd_history() {
 
 cmd_diff() {
   local name="" ref=""
-  for arg in "$@"; do
-    if [[ -d "$PROFILES_DIR/$arg" ]]; then
-      name="$arg"
+  if [[ $# -gt 2 ]]; then
+    err "Usage: claude-profile diff [name] [commit|date]"
+    exit 1
+  fi
+  if [[ $# -eq 2 ]]; then
+    # Two args are positional: <name> <ref> — never silently demote a
+    # misspelled profile name to a ref
+    name="$1" ref="$2"
+    _validate_profile_name "$name"
+    _require_profile_exists "$name"
+  elif [[ $# -eq 1 ]]; then
+    if [[ -d "$PROFILES_DIR/$1" ]]; then
+      name="$1"
     else
-      ref="$arg"
+      ref="$1"
     fi
-  done
+  fi
 
   name="${name:-$(get_current)}"
   _require_profile_name "$name" "claude-profile diff [name] [commit|date]"
@@ -45,7 +56,9 @@ _snapshot_live_for_diff() {
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     local base
     base="$(basename "$f")"
-    if [[ "$base" == "." || "$base" == ".." ]]; then
+    # The user's live .git/.gitignore must not be ingested — a live
+    # .gitignore's rules would hide untracked changes from the diff
+    if _skip_entry "$base"; then
       continue
     fi
     if [[ -e "$f" ]]; then
@@ -163,20 +176,28 @@ _diff_since_ref() {
 }
 
 cmd_restore() {
-  local name="" ref=""
+  local name="" ref="" arg
   for arg in "$@"; do
     if [[ "$arg" =~ [/[:cntrl:]] || "$arg" == .* || "$arg" == -* ]]; then
       err "Invalid profile name '$arg' (must start with alphanumeric, no slashes or dots)"
       exit 1
     fi
-    if [[ -d "$PROFILES_DIR/$arg" ]]; then
-      name="$arg"
-    else
-      ref="$arg"
-    fi
   done
+  if [[ $# -eq 1 ]]; then
+    ref="$1"
+  elif [[ $# -eq 2 ]]; then
+    # Two args are positional: <name> <ref> — never silently demote a
+    # misspelled profile name to a ref and roll back the active profile
+    name="$1" ref="$2"
+    _validate_profile_name "$name"
+    _require_profile_exists "$name"
+  elif [[ $# -gt 2 ]]; then
+    err "Usage: claude-profile restore [name] <commit|date>"; exit 1
+  fi
 
-  name="${name:-$(get_current)}"
+  _refuse_if_op_interrupted
+
+  name="${name:-$(get_current_validated)}"
   if [[ -n "$name" ]]; then
     _validate_profile_name "$name"
   fi
@@ -196,9 +217,19 @@ cmd_restore() {
   short="$(git -C "$profile_dir" log --format='%h %s' -1 "$resolved" --)"
   info "Restoring $(_pname "$name") to: ${YELLOW}$short${NC}"
 
-  # Auto-save unsaved live changes if this is the active profile
+  # Auto-save unsaved live changes if this is the active profile; for a
+  # non-active profile, commit any stray working-tree edits the same way
   if [[ "$(get_current)" == "$name" ]]; then
     _save_current_to "$profile_dir" "Auto-save before restore to $ref"
+  else
+    _git_commit "$profile_dir" "Auto-save before restore to $ref"
+  fi
+  # The rollback deletes the working tree first — proceed only if that
+  # safety-net commit actually landed
+  if [[ -n "$(git -C "$profile_dir" status --porcelain 2>/dev/null)" ]]; then
+    err "Unsaved changes could not be committed — aborting restore (profile and live files untouched)"
+    err "Fix git in $profile_dir (e.g. configure user.name/user.email), then retry"
+    exit 1
   fi
 
   # Full rollback: remove tracked files that don't exist in the target commit,
@@ -209,7 +240,8 @@ cmd_restore() {
     exit 1
   fi
   if ! git -C "$profile_dir" checkout "$resolved" -- . 2>/dev/null; then
-    err "Failed to checkout $ref — profile unchanged"
+    git -C "$profile_dir" checkout HEAD -- . 2>/dev/null || true
+    err "Failed to check out $ref — the profile was restored to its last saved state instead"
     exit 1
   fi
   _git_commit "$profile_dir" "Restored to $ref"
@@ -217,7 +249,9 @@ cmd_restore() {
   # If active, reload into live locations
   if [[ "$(get_current)" == "$name" ]]; then
     info "Reloading active profile..."
+    _set_op_marker "use $name"
     _load_profile_to_live "$profile_dir"
+    _clear_op_marker
   fi
 
   ok "Restored $(_pname "$name") to ${YELLOW}$ref${NC}"

--- a/commands/info.sh
+++ b/commands/info.sh
@@ -51,13 +51,21 @@ cmd_edit() {
   _refuse_if_op_interrupted
 
   # Auto-save live state so the profile dir has the latest files
+  local is_active=false
   if [[ "$(get_current)" == "$name" ]]; then
+    is_active=true
     _save_current_to "$PROFILES_DIR/$name" "Auto-save before edit"
   fi
 
   local profile_dir="$PROFILES_DIR/$name"
+  # A shell-split $EDITOR (vim, nano, "code --wait") runs to completion before
+  # returning — the only case where we can reliably reload the edit afterwards.
+  # `code` (no --wait) / `open` return immediately, so a reload would just race
+  # the still-open editor; leave those as before.
+  local blocking=false
   if [[ -n "${EDITOR:-}" ]]; then
     # EDITOR may carry arguments ("code --wait") — let a shell split it
+    blocking=true
     sh -c "$EDITOR \"\$1\"" claude-profile-edit "$profile_dir"
   elif command -v code &>/dev/null; then
     code "$profile_dir"
@@ -65,6 +73,17 @@ cmd_edit() {
     open "$profile_dir"
   else
     echo "$profile_dir"
+  fi
+
+  # Editing the ACTIVE profile writes into the profile dir, but live ~/.claude
+  # still holds the pre-edit state — the next save/switch would overwrite the
+  # edit from live. Reload the profile dir into live so the edit is the
+  # authoritative state. Bracket the destructive reload with the op marker so a
+  # crash mid-reload is recoverable (the profile dir keeps its copy).
+  if [[ "$is_active" == true && "$blocking" == true ]]; then
+    _set_op_marker "use $name"
+    _load_profile_to_live "$profile_dir"
+    _clear_op_marker
   fi
 }
 

--- a/commands/info.sh
+++ b/commands/info.sh
@@ -26,7 +26,7 @@ cmd_list() {
 
 cmd_current() {
   local current
-  current="$(get_current)"
+  current="$(get_current_validated)"
   if [[ -n "$current" ]]; then
     echo "$current"
   else
@@ -48,6 +48,7 @@ cmd_edit() {
   local name="${1:-$(get_current)}"
   _require_profile_name "$name" "claude-profile edit <name>"
   _require_profile_exists "$name"
+  _refuse_if_op_interrupted
 
   # Auto-save live state so the profile dir has the latest files
   if [[ "$(get_current)" == "$name" ]]; then
@@ -55,10 +56,11 @@ cmd_edit() {
   fi
 
   local profile_dir="$PROFILES_DIR/$name"
-  if command -v code &>/dev/null; then
+  if [[ -n "${EDITOR:-}" ]]; then
+    # EDITOR may carry arguments ("code --wait") — let a shell split it
+    sh -c "$EDITOR \"\$1\"" claude-profile-edit "$profile_dir"
+  elif command -v code &>/dev/null; then
     code "$profile_dir"
-  elif [[ -n "${EDITOR:-}" ]]; then
-    "$EDITOR" "$profile_dir"
   elif [[ "$(uname)" == "Darwin" ]]; then
     open "$profile_dir"
   else
@@ -67,12 +69,23 @@ cmd_edit() {
 }
 
 cmd_delete() {
-  local name="${1:-}" force=0
-  [[ "$name" == "-f" || "$name" == "--force" ]] && { force=1; name="${2:-}"; }
-  [[ "${2:-}" == "-f" || "${2:-}" == "--force" ]] && force=1
+  local name="" force=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f|--force) force=1; shift ;;
+      *)
+        if [[ -n "$name" ]]; then
+          err "Unexpected argument: '$1'"
+          err "Usage: claude-profile delete <name> [-f]"
+          exit 1
+        fi
+        name="$1"; shift ;;
+    esac
+  done
 
   _require_profile_name "$name" "claude-profile delete <name> [-f]"
   _require_profile_exists "$name"
+  _refuse_if_op_interrupted
 
   local current
   current="$(get_current)"

--- a/commands/info.sh
+++ b/commands/info.sh
@@ -101,6 +101,7 @@ cmd_delete() {
     [[ "$confirm" =~ ^[Yy]$ ]] || { info "Cancelled"; return; }
   fi
 
+  _assert_profile_path_safe "$PROFILES_DIR/$name"
   rm -rf "$PROFILES_DIR/$name"
   ok "Deleted $(_pname "$name")"
 }

--- a/commands/profile.sh
+++ b/commands/profile.sh
@@ -1,5 +1,28 @@
 # profile.sh — Core profile operations: new, fork, use, save, deactivate
 
+# A `use` that died mid-load leaves live ~/.claude holding a partial copy of
+# the marker's target while .current still names the old profile. Any
+# auto-save at that point would absorb the target's files into the wrong
+# profile — so first move them back where they came from.
+_recover_interrupted_switch() {
+  local op target
+  op="$(_get_op_marker)"
+  if [[ -z "$op" ]]; then
+    return 0
+  fi
+  if [[ "$op" != "use "* ]]; then
+    _refuse_if_op_interrupted
+  fi
+  target="${op#use }"
+  if [[ -z "$target" || "$target" =~ [^a-zA-Z0-9._-] || "$target" == .* || "$target" == -* ]]; then
+    err "Interrupted-operation marker is corrupt — inspect and remove $OP_MARKER_FILE manually"
+    exit 1
+  fi
+  warn "A previous switch to $(_pname "$target") was interrupted — recovering..."
+  _sweep_live_entries_to "$PROFILES_DIR/$target"
+  _clear_op_marker
+}
+
 # Guard for use/new: when the auto-save will not run — no profile is current
 # (detached after deactivate), or .current names a profile dir that no longer
 # exists — loading a profile would destroy live config that is not saved in
@@ -39,10 +62,17 @@ cmd_new() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --force) force=true; shift ;;
-      *)       name="$1"; shift ;;
+      *)
+        if [[ -n "$name" ]]; then
+          err "Unexpected argument: '$1'"
+          err "Usage: claude-profile new <name> [--force]"
+          exit 1
+        fi
+        name="$1"; shift ;;
     esac
   done
   _require_profile_name "$name" "claude-profile new <name> [--force]"
+  _refuse_if_op_interrupted
 
   # Capture before _ensure_original_backup — a pre-existing backup does NOT
   # cover config created later, so it can't justify wiping the live state.
@@ -72,14 +102,22 @@ cmd_new() {
 
   _git_init "$profile_dir"
 
+  _set_op_marker "use $name"
   _load_profile_to_live "$profile_dir"
   set_current "$name"
+  _clear_op_marker
   ok "Created and activated $(_pname "$name") ${DIM}(clean)${NC}"
 }
 
 cmd_fork() {
   local name="${1:-}"
+  if [[ $# -gt 1 ]]; then
+    err "Unexpected argument: '$2'"
+    err "Usage: claude-profile fork <name>"
+    exit 1
+  fi
   _require_profile_name "$name" "claude-profile fork <name>"
+  _refuse_if_op_interrupted
   _ensure_original_backup
 
   local profile_dir="$PROFILES_DIR/$name"
@@ -119,7 +157,13 @@ cmd_use() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --force) force=true; shift ;;
-      *)       name="$1"; shift ;;
+      *)
+        if [[ -n "$name" ]]; then
+          err "Unexpected argument: '$1'"
+          err "Usage: claude-profile use <name> [--force]"
+          exit 1
+        fi
+        name="$1"; shift ;;
     esac
   done
   _require_profile_name "$name" "claude-profile use <name> [--force]"
@@ -131,11 +175,24 @@ cmd_use() {
     exit 1
   fi
 
+  _recover_interrupted_switch
+
   local current
   current="$(get_current_validated)"
 
   if [[ "$current" == "$name" ]]; then
-    ok "$(_pname "$name") is already active"
+    if _live_state_nonempty || ! _dir_has_entries "$profile_dir"; then
+      ok "$(_pname "$name") is already active"
+      return
+    fi
+    # The live config is gone (e.g. an interrupted switch) but the profile
+    # still holds it — reload instead of pretending all is well.
+    warn "Live config is empty — reloading $(_pname "$name")"
+    _set_op_marker "use $name"
+    _load_profile_to_live "$profile_dir" --move
+    _clear_op_marker
+    ok "Active profile: $(_pname "$name")"
+    _show_profile_summary "$name"
     return
   fi
 
@@ -159,9 +216,11 @@ cmd_use() {
   fi
 
   info "Switching to $(_pname "$name")..."
+  _set_op_marker "use $name"
   _load_profile_to_live "$profile_dir" --move
 
   set_current "$name"
+  _clear_op_marker
   ok "Active profile: $(_pname "$name")"
   _show_profile_summary "$name"
 }
@@ -170,13 +229,25 @@ cmd_save() {
   local name="" msg=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -m) msg="${2:?-m requires a message}"; shift 2 ;;
-      *)  name="$1"; shift ;;
+      -m)
+        if [[ $# -lt 2 ]]; then
+          err "-m requires a message"
+          exit 1
+        fi
+        msg="$2"; shift 2 ;;
+      *)
+        if [[ -n "$name" ]]; then
+          err "Unexpected argument: '$1'"
+          err "Usage: claude-profile save [name] [-m message]"
+          exit 1
+        fi
+        name="$1"; shift ;;
     esac
   done
 
   name="${name:-$(get_current_validated)}"
   _require_profile_name "$name" "claude-profile save [name] [-m message]"
+  _refuse_if_op_interrupted
   _ensure_original_backup
 
   local profile_dir="$PROFILES_DIR/$name"
@@ -242,6 +313,20 @@ cmd_deactivate() {
     esac
   done
 
+  # A deactivate that died mid-restore is completed here (skipping the
+  # auto-save — live holds a partial backup copy, not user data). Any other
+  # interrupted operation must be recovered by its own command first.
+  local resume_restore=false op
+  op="$(_get_op_marker)"
+  if [[ -n "$op" ]]; then
+    if [[ "$op" == "deactivate" && "$keep" != true ]]; then
+      warn "A previous deactivate was interrupted — completing the restore..."
+      resume_restore=true
+    else
+      _refuse_if_op_interrupted
+    fi
+  fi
+
   local current
   current="$(get_current_validated)"
   local backup_dir="$PROFILES_DIR/.pre-profiles-backup"
@@ -270,7 +355,13 @@ cmd_deactivate() {
       warn "No profile is active"; return
     fi
 
-    if [[ -n "$current" ]]; then
+    # Validate the backup BEFORE the destructive auto-save — a backup that
+    # cannot be loaded must be discovered while the live files are untouched
+    _validate_profile_for_load "$backup_dir" || return 1
+
+    if [[ "$resume_restore" == true ]]; then
+      : # live holds a partial restore — nothing of the user's to save
+    elif [[ -n "$current" ]]; then
       info "Saving $(_pname "$current")..."
       _save_current_to "$PROFILES_DIR/$current" "Auto-save before deactivate" --move
     elif _live_state_nonempty && ! _live_state_equals_dir "$backup_dir" && ! _live_state_saved_in_any_profile; then
@@ -283,9 +374,11 @@ cmd_deactivate() {
       _git_init "$detached_dir"
     fi
 
+    _set_op_marker "deactivate"
     info "Restoring original state..."
     _restore_from_backup
     clear_current
+    _clear_op_marker
     if [[ -n "$current" ]]; then
       ok "Deactivated $(_pname "$current"), restored original state"
     else

--- a/commands/profile.sh
+++ b/commands/profile.sh
@@ -1,25 +1,34 @@
 # profile.sh — Core profile operations: new, fork, use, save, deactivate
 
-# A `use` that died mid-load leaves live ~/.claude holding a partial copy of
-# the marker's target while .current still names the old profile. Any
-# auto-save at that point would absorb the target's files into the wrong
-# profile — so first move them back where they came from.
+# Recover a switch that died mid-flight. The marker's PHASE says which side the
+# half-moved live state belongs to: during the outgoing save (saving) live is a
+# partial copy of the SOURCE, during the incoming load (loading) it is a partial
+# copy of the TARGET. Sweep it back to that side with a non-destructive move —
+# never the exact-sync save, which would delete a profile's sole copy. After a
+# saving-phase sweep live is empty and .current still names the source, so the
+# re-driven command's auto-save no-ops instead of propagating deletions.
 _recover_interrupted_switch() {
-  local op target
-  op="$(_get_op_marker)"
-  if [[ -z "$op" ]]; then
-    return 0
-  fi
-  if [[ "$op" != "use "* ]]; then
+  _parse_op_marker || return 0
+  if [[ "$_OP" != "use" ]]; then
+    # deactivate/unknown are recovered by their own command, not here.
     _refuse_if_op_interrupted
   fi
-  target="${op#use }"
-  if [[ -z "$target" || "$target" =~ [^a-zA-Z0-9._-] || "$target" == .* || "$target" == -* ]]; then
+  local dest
+  if [[ "$_OP_PHASE" == "saving" ]]; then
+    dest="$_OP_SOURCE"
+  else
+    dest="$_OP_TARGET"
+  fi
+  if [[ -z "$dest" || "$dest" =~ [^a-zA-Z0-9._-] || "$dest" == .* || "$dest" == -* ]]; then
     err "Interrupted-operation marker is corrupt — inspect and remove $OP_MARKER_FILE manually"
     exit 1
   fi
-  warn "A previous switch to $(_pname "$target") was interrupted — recovering..."
-  _sweep_live_entries_to "$PROFILES_DIR/$target"
+  if [[ "$_OP_PHASE" == "saving" ]]; then
+    warn "A previous switch away from $(_pname "$dest") was interrupted — recovering..."
+  else
+    warn "A previous switch to $(_pname "$dest") was interrupted — recovering..."
+  fi
+  _sweep_live_entries_to "$PROFILES_DIR/$dest"
   _clear_op_marker
 }
 
@@ -93,6 +102,9 @@ cmd_new() {
   _guard_detached_live_state "$current" "$force" "$backup_preexisted"
   if [[ -n "$current" && -d "$PROFILES_DIR/$current" ]]; then
     info "Saving profile $(_pname "$current")..."
+    # Mark the saving phase BEFORE the first destructive move — a crash here
+    # recovers by sweeping the half-moved live state back to the source.
+    _mark_op use saving "$current" "$name"
     _save_current_to "$PROFILES_DIR/$current" "Auto-save before new '$name'" --move
   fi
 
@@ -102,7 +114,7 @@ cmd_new() {
 
   _git_init "$profile_dir"
 
-  _set_op_marker "use $name"
+  _mark_op use loading "$current" "$name"
   _load_profile_to_live "$profile_dir"
   set_current "$name"
   _clear_op_marker
@@ -209,14 +221,17 @@ cmd_use() {
   # Pre-validate target profile before any destructive operations
   _validate_profile_for_load "$profile_dir" || exit 1
 
-  # Auto-save current profile before switching
+  # Auto-save current profile before switching. Mark the saving phase BEFORE
+  # the first destructive move so a crash mid-save recovers by sweeping the
+  # half-moved live state back to the source — never exact-sync-deleting it.
   if [[ -n "$current" && -d "$PROFILES_DIR/$current" ]]; then
     info "Saving $(_pname "$current")..."
+    _mark_op use saving "$current" "$name"
     _save_current_to "$PROFILES_DIR/$current" "Auto-save before switch to '$name'" --move
   fi
 
   info "Switching to $(_pname "$name")..."
-  _set_op_marker "use $name"
+  _mark_op use loading "$current" "$name"
   _load_profile_to_live "$profile_dir" --move
 
   set_current "$name"
@@ -313,15 +328,30 @@ cmd_deactivate() {
     esac
   done
 
-  # A deactivate that died mid-restore is completed here (skipping the
-  # auto-save — live holds a partial backup copy, not user data). Any other
-  # interrupted operation must be recovered by its own command first.
-  local resume_restore=false op
-  op="$(_get_op_marker)"
-  if [[ -n "$op" ]]; then
-    if [[ "$op" == "deactivate" && "$keep" != true ]]; then
-      warn "A previous deactivate was interrupted — completing the restore..."
-      resume_restore=true
+  # A deactivate that died mid-flight is recovered here. Any other interrupted
+  # operation must be recovered by its own command first.
+  #   phase=saving  — died during the outgoing --move; sweep the half-moved live
+  #                   state back to the source so its sole copy isn't lost, then
+  #                   fall through to a fresh deactivate (live is empty after).
+  #   phase=restore — died mid-restore; live holds a partial backup copy (not
+  #                   user data), so re-run the restore and skip the auto-save.
+  local resume_restore=false
+  _parse_op_marker || true
+  if [[ -n "$_OP" ]]; then
+    if [[ "$_OP" == "deactivate" && "$keep" != true ]]; then
+      if [[ "$_OP_PHASE" == "saving" ]]; then
+        local src="$_OP_SOURCE"
+        if [[ -z "$src" || "$src" =~ [^a-zA-Z0-9._-] || "$src" == .* || "$src" == -* ]]; then
+          err "Interrupted-operation marker is corrupt — inspect and remove $OP_MARKER_FILE manually"
+          exit 1
+        fi
+        warn "A previous deactivate was interrupted mid-save — recovering..."
+        _sweep_live_entries_to "$PROFILES_DIR/$src"
+        _clear_op_marker
+      else
+        warn "A previous deactivate was interrupted — completing the restore..."
+        resume_restore=true
+      fi
     else
       _refuse_if_op_interrupted
     fi
@@ -363,6 +393,8 @@ cmd_deactivate() {
       : # live holds a partial restore — nothing of the user's to save
     elif [[ -n "$current" ]]; then
       info "Saving $(_pname "$current")..."
+      # Saving phase marker BEFORE the first destructive move (see cmd_use).
+      _mark_op deactivate saving "$current" ""
       _save_current_to "$PROFILES_DIR/$current" "Auto-save before deactivate" --move
     elif _live_state_nonempty && ! _live_state_equals_dir "$backup_dir" && ! _live_state_saved_in_any_profile; then
       local detached_name detached_dir

--- a/commands/ui.sh
+++ b/commands/ui.sh
@@ -1,41 +1,91 @@
 # ui.sh — Shell prompt and Claude Code status line integration
 
-# Safely merge a key into a JSON file. Uses jq, python3, or node (first available).
+# Resolve a chain of symlinks to the real file path, portably (macOS `readlink`
+# has no -f). Non-symlinks pass through unchanged.
+_resolve_symlink() {
+  local f="$1" target
+  while [[ -L "$f" ]]; do
+    target="$(readlink "$f")"
+    if [[ "$target" == /* ]]; then
+      f="$target"
+    else
+      f="$(dirname "$f")/$target"
+    fi
+  done
+  printf '%s\n' "$f"
+}
+
+# True (0) when $file parses as JSON with any available tool.
+_json_valid() {
+  local file="$1"
+  if command -v jq &>/dev/null; then
+    jq -e . "$file" >/dev/null 2>&1
+    return
+  fi
+  if command -v python3 &>/dev/null; then
+    python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$file" >/dev/null 2>&1
+    return
+  fi
+  if command -v node &>/dev/null; then
+    node -e 'JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"))' "$file" >/dev/null 2>&1
+    return
+  fi
+  return 1
+}
+
+# Merge a key into a JSON file. Uses jq, python3, or node (first available).
+# The merged JSON is built in a temp beside the *resolved* target and then
+# atomically renamed onto it — a symlinked settings.json stays a symlink, an
+# interrupted or unpermitted write never truncates the original, and the write
+# is checked so callers hear about a failure instead of a false success.
+# Returns 1 on any failure (no tool, invalid JSON, unwritable target).
 _json_merge() {
   local file="$1" key="$2" value="$3"
-  local tmp
+  local real dir tmp produced=1
+
+  real="$(_resolve_symlink "$file")"
+  dir="$(dirname "$real")"
+  tmp="$(mktemp "$dir/.statusline-merge.XXXXXX" 2>/dev/null)" || return 1
 
   if command -v jq &>/dev/null; then
-    tmp="$(mktemp)"
     if jq --arg k "$key" --arg v "$value" '. + {($k): {"type": "command", "command": $v}}' "$file" > "$tmp" 2>/dev/null; then
-      # Write through (not mv) so a symlinked settings.json stays a symlink
-      cat "$tmp" > "$file"
-      rm -f "$tmp"
-      return 0
+      produced=0
     fi
-    rm -f "$tmp"
   fi
 
-  if command -v python3 &>/dev/null; then
-    python3 -c "
+  if [[ $produced -ne 0 ]] && command -v python3 &>/dev/null; then
+    if python3 -c "
 import json, sys
-p = sys.argv[1]
-with open(p) as f: d = json.load(f)
+with open(sys.argv[1]) as f: d = json.load(f)
 d[sys.argv[2]] = {'type': 'command', 'command': sys.argv[3]}
-with open(p, 'w') as f: json.dump(d, f, indent=2)
-" "$file" "$key" "$value" 2>/dev/null && return 0
+with open(sys.argv[4], 'w') as f: json.dump(d, f, indent=2)
+" "$file" "$key" "$value" "$tmp" 2>/dev/null; then
+      produced=0
+    fi
   fi
 
-  if command -v node &>/dev/null; then
-    node -e "
-const fs=require('fs'), f=process.argv[1];
-const d=JSON.parse(fs.readFileSync(f,'utf8'));
+  if [[ $produced -ne 0 ]] && command -v node &>/dev/null; then
+    if node -e "
+const fs=require('fs');
+const d=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));
 d[process.argv[2]]={type:'command',command:process.argv[3]};
-fs.writeFileSync(f,JSON.stringify(d,null,2)+'\n');
-" "$file" "$key" "$value" 2>/dev/null && return 0
+fs.writeFileSync(process.argv[4],JSON.stringify(d,null,2)+'\n');
+" "$file" "$key" "$value" "$tmp" 2>/dev/null; then
+      produced=0
+    fi
   fi
 
-  return 1
+  if [[ $produced -ne 0 ]]; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  # Atomic replace at the resolved target keeps the symlink (if any) intact.
+  if ! mv "$tmp" "$real"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  return 0
 }
 
 cmd_statusline() {
@@ -82,10 +132,12 @@ SCRIPT
           if _json_merge "$settings" "statusLine" "$statusline_script"; then
             ok "Status line configured in settings.json"
           else
-            if command -v jq &>/dev/null || command -v python3 &>/dev/null || command -v node &>/dev/null; then
+            if ! command -v jq &>/dev/null && ! command -v python3 &>/dev/null && ! command -v node &>/dev/null; then
+              err "Could not update settings.json (no jq, python3, or node found)"
+            elif ! _json_valid "$settings"; then
               err "Could not update settings.json — it is not valid JSON"
             else
-              err "Could not update settings.json (no jq, python3, or node found)"
+              err "Could not update settings.json — check that its directory is writable"
             fi
             info "Add manually to settings.json:"
             echo "  \"statusLine\": { \"type\": \"command\", \"command\": \"$statusline_script\" }"

--- a/commands/ui.sh
+++ b/commands/ui.sh
@@ -8,7 +8,10 @@ _json_merge() {
   if command -v jq &>/dev/null; then
     tmp="$(mktemp)"
     if jq --arg k "$key" --arg v "$value" '. + {($k): {"type": "command", "command": $v}}' "$file" > "$tmp" 2>/dev/null; then
-      mv "$tmp" "$file"; return 0
+      # Write through (not mv) so a symlinked settings.json stays a symlink
+      cat "$tmp" > "$file"
+      rm -f "$tmp"
+      return 0
     fi
     rm -f "$tmp"
   fi
@@ -36,7 +39,7 @@ fs.writeFileSync(f,JSON.stringify(d,null,2)+'\n');
 }
 
 cmd_statusline() {
-  local action="${1:-install}"
+  local action="${1:-}"
   ensure_dir
   local statusline_script="$PROFILES_DIR/statusline.sh"
 
@@ -79,7 +82,11 @@ SCRIPT
           if _json_merge "$settings" "statusLine" "$statusline_script"; then
             ok "Status line configured in settings.json"
           else
-            err "Could not update settings.json (no jq, python3, or node found)"
+            if command -v jq &>/dev/null || command -v python3 &>/dev/null || command -v node &>/dev/null; then
+              err "Could not update settings.json — it is not valid JSON"
+            else
+              err "Could not update settings.json (no jq, python3, or node found)"
+            fi
             info "Add manually to settings.json:"
             echo "  \"statusLine\": { \"type\": \"command\", \"command\": \"$statusline_script\" }"
             exit 1

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -16,13 +16,16 @@ If you already detached with `deactivate --keep`, the same command restores the 
 **If `claude-profile` is no longer installed**, restore manually:
 
 ```bash
-# Copy files from the backup to their live locations
-cp -R ~/.local/share/claude-profile/.pre-profiles-backup/* ~/.claude/
-cp -R ~/.local/share/claude-profile/.pre-profiles-backup/.claude.json ~/.claude.json
+# Copy everything from the backup — the trailing /. includes dotfiles
+# (e.g. .credentials.json), which a bare * glob would skip
+mkdir -p ~/.claude
+cp -R ~/.local/share/claude-profile/.pre-profiles-backup/. ~/.claude/
+# .claude.json lives in $HOME, not inside ~/.claude/
+mv -f ~/.claude/.claude.json ~/.claude.json 2>/dev/null || true
 rm -f ~/.local/share/claude-profile/.current
 ```
 
-Not every file will exist — `cp` will print errors for missing ones, which is fine.
+Not every file will exist — errors about missing ones are fine.
 
 ## Step 2: Remove the CLI
 

--- a/install.sh
+++ b/install.sh
@@ -51,9 +51,12 @@ COMPLETIONS_NEED_SETUP=""
 
 expand_home_path() {
   local path="$1"
+  local zsh_dir="${ZSH:-$HOME/.oh-my-zsh}"
   path="${path/#\~/$HOME}"
   path="${path//\$\{HOME\}/$HOME}"
   path="${path//\$HOME/$HOME}"
+  path="${path//\$\{ZSH\}/$zsh_dir}"
+  path="${path//\$ZSH/$zsh_dir}"
   printf '%s\n' "$path"
 }
 
@@ -62,19 +65,30 @@ detect_oh_my_zsh_custom_dir() {
   local custom_dir=""
 
   if [[ -n "${ZSH_CUSTOM:-}" ]]; then
-    expand_home_path "$ZSH_CUSTOM"
-    return 0
+    custom_dir="$(expand_home_path "$ZSH_CUSTOM")"
+    if [[ "$custom_dir" == /* ]]; then
+      printf '%s\n' "$custom_dir"
+      return 0
+    fi
+    custom_dir=""
   fi
 
   if [[ -f "$rc" ]]; then
     custom_dir="$(sed -nE 's/^[[:space:]]*(export[[:space:]]+)?ZSH_CUSTOM=//p' "$rc" | tail -n 1)"
+    custom_dir="${custom_dir%%#*}"
+    custom_dir="$(printf '%s' "$custom_dir" | sed -E 's/[[:space:]]+$//')"
     custom_dir="${custom_dir%\"}"
     custom_dir="${custom_dir#\"}"
     custom_dir="${custom_dir%\'}"
     custom_dir="${custom_dir#\'}"
     if [[ -n "$custom_dir" ]]; then
-      expand_home_path "$custom_dir"
-      return 0
+      custom_dir="$(expand_home_path "$custom_dir")"
+      # Only trust an absolute result — a relative path would create a junk
+      # directory in whatever cwd the installer runs from
+      if [[ "$custom_dir" == /* ]]; then
+        printf '%s\n' "$custom_dir"
+        return 0
+      fi
     fi
   fi
 
@@ -187,7 +201,10 @@ if [[ ! -d "$SEED_DIR" ]]; then
 fi
 
 # ─── Install statusline ─────────────────────────────────────
-"$INSTALL_DIR/claude-profile" statusline install
+# Cosmetic step — its failure must not abort PATH/completion setup below
+if ! "$INSTALL_DIR/claude-profile" statusline install; then
+  echo -e "${RED}✗${NC} Status line setup failed — run 'claude-profile statusline install' manually" >&2
+fi
 
 # ─── Check PATH ─────────────────────────────────────────────
 if ! echo "$PATH" | tr ':' '\n' | grep -Fqx "$INSTALL_DIR"; then

--- a/install.sh
+++ b/install.sh
@@ -33,12 +33,16 @@ cp "$SCRIPT_DIR"/lib/*.sh "$INSTALL_LIB/lib/"
 cp "$SCRIPT_DIR"/commands/*.sh "$INSTALL_LIB/commands/"
 chmod +x "$INSTALL_DIR/claude-profile"
 
-# Patch SCRIPT_DIR in installed binary to point to lib location
-# Use awk with ENVIRON to avoid injection via special chars (|, &, \) in paths.
-# ENVIRON reads the raw env var value without processing escape sequences,
-# unlike awk -v which interprets \n, \t, etc.
-INSTALL_LIB="$INSTALL_LIB" awk '{
-  if ($0 ~ /^SCRIPT_DIR=/) print "SCRIPT_DIR=\"" ENVIRON["INSTALL_LIB"] "\""
+# Patch SCRIPT_DIR in installed binary to point to lib location.
+# `printf %q` renders the path as a single shell-safe token (it supplies its
+# own quoting/escaping), so the generated assignment stays inert even when the
+# path contains a double-quote, `;`, `$`, backtick, or newline. Emitting it
+# without surrounding literal quotes is what closes the injection: quoting the
+# awk output ourselves would let a `"` in the path break back out at re-source.
+# ENVIRON reads the raw value without processing escape sequences (unlike -v).
+SCRIPT_DIR_ASSIGN="SCRIPT_DIR=$(printf '%q' "$INSTALL_LIB")"
+SCRIPT_DIR_ASSIGN="$SCRIPT_DIR_ASSIGN" awk '{
+  if ($0 ~ /^SCRIPT_DIR=/) print ENVIRON["SCRIPT_DIR_ASSIGN"]
   else print
 }' "$INSTALL_DIR/claude-profile" > "$INSTALL_DIR/claude-profile.tmp"
 mv "$INSTALL_DIR/claude-profile.tmp" "$INSTALL_DIR/claude-profile"

--- a/install.sh
+++ b/install.sh
@@ -186,6 +186,39 @@ else
   PROFILES_DIR="$HOME/.local/share/claude-profile"
 fi
 
+# ─── Refuse pathological nesting before any store write ─────
+# Mirror the CLI's config.sh guard: a store inside the live dir (or the
+# reverse) makes the switch loops destroy the store. Canonicalize so a
+# trailing slash, `..`, a relative spelling, or a symlink can't slip past.
+canonical_path() {
+  local path="$1" tail="" dir parent base
+  dir="$path"
+  while [[ ! -e "$dir" ]]; do
+    base="$(basename "$dir")"
+    tail="/$base$tail"
+    parent="$(dirname "$dir")"
+    [[ "$parent" == "$dir" ]] && break
+    dir="$parent"
+  done
+  local canon
+  if canon="$(cd "$dir" 2>/dev/null && pwd -P)"; then
+    [[ "$canon" == "/" ]] && canon=""
+    local result="$canon$tail"
+    [[ -z "$result" ]] && result="/"
+    printf '%s\n' "$result"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+CANON_PROFILES="$(canonical_path "$PROFILES_DIR")"
+CANON_CLAUDE="$(canonical_path "$CLAUDE_DIR")"
+if [[ "$CANON_PROFILES" == "$CANON_CLAUDE" || "$CANON_PROFILES" == "$CANON_CLAUDE"/* ]]; then
+  err "Profile store ($PROFILES_DIR) must not be inside the live config dir ($CLAUDE_DIR) — set CLAUDE_PROFILE_HOME elsewhere"
+fi
+if [[ "$CANON_CLAUDE" == "$CANON_PROFILES"/* ]]; then
+  err "Live config dir ($CLAUDE_DIR) must not be inside the profile store ($PROFILES_DIR)"
+fi
+
 # ─── Migrate from old location ──────────────────────────────
 OLD_PROFILES_DIR="$CLAUDE_DIR/__profiles__"
 if [[ -d "$OLD_PROFILES_DIR" && ! -d "$PROFILES_DIR" && ! -L "$PROFILES_DIR" ]]; then

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -70,6 +70,16 @@ fi
 
 CURRENT_FILE="$PROFILES_DIR/.current"
 OP_MARKER_FILE="$PROFILES_DIR/.op-in-progress"
+STORE_FORMAT_FILE="$PROFILES_DIR/.format"
+STORE_FORMAT=2
+
+# The home-level ~/.claude.json is stored inside a profile under this reserved
+# name, keeping it in a namespace disjoint from the live payload — a live file
+# literally named ~/.claude/.claude.json is captured as the payload entry
+# ".claude.json" and no longer collides with (or is overwritten by) the home
+# file. Profiles written before format 2 kept the home file at the root as
+# ".claude.json"; startup migration moves it here.
+CLAUDE_HOME_JSON=".claude-profile-home.json"
 
 # Seed files for new (empty) profiles so Claude Code doesn't complain.
 # Parallel arrays: SEED_NAMES[i] is the filename, SEED_CONTENTS[i] is its content.

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -24,7 +24,21 @@ else
   PROFILES_DIR="$HOME/.local/share/claude-profile"
 fi
 
+# Refuse pathological nesting — the switch logic clears/copies whole
+# directories, so a store inside the live dir (or the reverse) would let those
+# loops destroy the store itself, including the original backup.
+if [[ "$PROFILES_DIR/" == "$CLAUDE_DIR"/* ]]; then
+  err "Profile store ($PROFILES_DIR) must not be inside the live config dir ($CLAUDE_DIR)"
+  err "Move it elsewhere and update CLAUDE_PROFILE_HOME"
+  exit 1
+fi
+if [[ "$CLAUDE_DIR/" == "$PROFILES_DIR"/* ]]; then
+  err "Live config dir ($CLAUDE_DIR) must not be inside the profile store ($PROFILES_DIR)"
+  exit 1
+fi
+
 CURRENT_FILE="$PROFILES_DIR/.current"
+OP_MARKER_FILE="$PROFILES_DIR/.op-in-progress"
 
 # Seed files for new (empty) profiles so Claude Code doesn't complain.
 # Parallel arrays: SEED_NAMES[i] is the filename, SEED_CONTENTS[i] is its content.

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -24,15 +24,46 @@ else
   PROFILES_DIR="$HOME/.local/share/claude-profile"
 fi
 
+# Canonicalize a path that may not fully exist yet: resolve the deepest
+# existing ancestor with `pwd -P` (following symlinks and normalizing `..`,
+# trailing slashes, and relative spellings), then re-append the missing tail.
+# macOS `realpath`/`readlink -f` aren't dependable, so do it in the shell.
+_canonical_path() {
+  local path="$1" tail="" dir parent base
+  dir="$path"
+  while [[ ! -e "$dir" ]]; do
+    base="$(basename "$dir")"
+    tail="/$base$tail"
+    parent="$(dirname "$dir")"
+    if [[ "$parent" == "$dir" ]]; then
+      break
+    fi
+    dir="$parent"
+  done
+  local canon
+  if canon="$(cd "$dir" 2>/dev/null && pwd -P)"; then
+    [[ "$canon" == "/" ]] && canon=""
+    local result="$canon$tail"
+    [[ -z "$result" ]] && result="/"
+    printf '%s\n' "$result"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
 # Refuse pathological nesting — the switch logic clears/copies whole
 # directories, so a store inside the live dir (or the reverse) would let those
-# loops destroy the store itself, including the original backup.
-if [[ "$PROFILES_DIR/" == "$CLAUDE_DIR"/* ]]; then
+# loops destroy the store itself, including the original backup. Compare
+# CANONICAL paths so a trailing slash, `..`, a relative spelling, or a symlink
+# alias can't smuggle the store inside the live dir past a raw string compare.
+_CANON_PROFILES_DIR="$(_canonical_path "$PROFILES_DIR")"
+_CANON_CLAUDE_DIR="$(_canonical_path "$CLAUDE_DIR")"
+if [[ "$_CANON_PROFILES_DIR" == "$_CANON_CLAUDE_DIR" || "$_CANON_PROFILES_DIR" == "$_CANON_CLAUDE_DIR"/* ]]; then
   err "Profile store ($PROFILES_DIR) must not be inside the live config dir ($CLAUDE_DIR)"
   err "Move it elsewhere and update CLAUDE_PROFILE_HOME"
   exit 1
 fi
-if [[ "$CLAUDE_DIR/" == "$PROFILES_DIR"/* ]]; then
+if [[ "$_CANON_CLAUDE_DIR" == "$_CANON_PROFILES_DIR"/* ]]; then
   err "Live config dir ($CLAUDE_DIR) must not be inside the profile store ($PROFILES_DIR)"
   exit 1
 fi

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -266,11 +266,17 @@ _save_current_to() {
     fi
   done
   rm -rf "$staging" 2>/dev/null || true
-  # Special: always copy ~/.claude.json (even with --move, since it lives
-  # outside CLAUDE_DIR); its deletion propagates too
+  # Special: always capture ~/.claude.json (even with --move, since it lives
+  # outside CLAUDE_DIR); its deletion propagates too. With --move also remove
+  # the live copy, so the outgoing move leaves live COMPLETELY empty — a crash
+  # at the save/load boundary then has nothing left for recovery to sweep into
+  # the wrong profile (the load restores the target's own .claude.json).
   if [[ -e "$HOME/.claude.json" ]]; then
     rm -rf "${dst:?}/.claude.json"
     cp -RL "$HOME/.claude.json" "$dst/.claude.json"
+    if [[ "$move" == "--move" ]]; then
+      rm -f "$HOME/.claude.json"
+    fi
   else
     rm -rf "${dst:?}/.claude.json"
   fi

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -31,9 +31,26 @@ _assert_profile_path_safe() {
 # clear/summary loop runs through this predicate.
 _skip_entry() {
   case "$1" in
-    . | .. | .git | .gitignore) return 0 ;;
+    . | .. | .git | .gitignore | .claude-profile-home.json) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# Path at which a profile stores the home-level ~/.claude.json.
+_profile_home_json() { printf '%s\n' "$1/$CLAUDE_HOME_JSON"; }
+
+# Path to read a profile's stored home file, tolerating the legacy layout
+# (root .claude.json) for a profile that predates format-2 migration. Prints a
+# path that may not exist (the reserved location) when neither is present.
+_profile_home_json_read() {
+  local dir="$1"
+  if [[ -e "$dir/$CLAUDE_HOME_JSON" ]]; then
+    printf '%s\n' "$dir/$CLAUDE_HOME_JSON"
+  elif [[ -e "$dir/.claude.json" && ! -d "$dir/.claude.json" ]]; then
+    printf '%s\n' "$dir/.claude.json"
+  else
+    printf '%s\n' "$dir/$CLAUDE_HOME_JSON"
+  fi
 }
 
 # Where copy-mode saves stage each entry before atomically moving it into a
@@ -123,7 +140,7 @@ _live_state_equals_dir() {
   # Entries only in $dir mean the live state lost something — not identical
   for f in "$dir"/* "$dir"/.*; do
     base="$(basename "$f")"
-    if _skip_entry "$base" || [[ "$base" == ".claude.json" ]]; then
+    if _skip_entry "$base"; then
       continue
     fi
     if [[ ! -L "$f" && ! -e "$f" ]]; then
@@ -133,9 +150,12 @@ _live_state_equals_dir() {
       return 1
     fi
   done
-  # Special: ~/.claude.json lives outside CLAUDE_DIR — compare it explicitly
-  if [[ -e "$HOME/.claude.json" || -e "$dir/.claude.json" ]]; then
-    if ! diff -q "$HOME/.claude.json" "$dir/.claude.json" >/dev/null 2>&1; then
+  # Special: ~/.claude.json lives outside CLAUDE_DIR — compare it against the
+  # profile's reserved home file (tolerating the legacy root layout).
+  local dir_home
+  dir_home="$(_profile_home_json_read "$dir")"
+  if [[ -e "$HOME/.claude.json" || -e "$dir_home" ]]; then
+    if ! diff -q "$HOME/.claude.json" "$dir_home" >/dev/null 2>&1; then
       return 1
     fi
   fi
@@ -156,13 +176,24 @@ _seed_profile() {
         continue
       fi
       if [[ -e "$f" ]]; then
-        cp -RL "$f" "$dst/"
+        # A seed entry named .claude.json is the home-file template — store it
+        # at the reserved home location, not as a live-payload entry.
+        if [[ "$base" == ".claude.json" ]]; then
+          cp -RL "$f" "$(_profile_home_json "$dst")"
+        else
+          cp -RL "$f" "$dst/$base"
+        fi
       fi
     done
   else
-    local i
+    local i name
     for i in "${!SEED_NAMES[@]}"; do
-      echo "${SEED_CONTENTS[$i]}" > "$dst/${SEED_NAMES[$i]}"
+      name="${SEED_NAMES[$i]}"
+      if [[ "$name" == ".claude.json" ]]; then
+        echo "${SEED_CONTENTS[$i]}" > "$(_profile_home_json "$dst")"
+      else
+        echo "${SEED_CONTENTS[$i]}" > "$dst/$name"
+      fi
     done
   fi
 }
@@ -191,9 +222,9 @@ _snapshot_current() {
       cp -RL "$f" "$dst/$base"
     fi
   done
-  # Special: always copy ~/.claude.json
+  # Special: always copy ~/.claude.json to the reserved home location
   if [[ -e "$HOME/.claude.json" ]]; then
-    cp -RL "$HOME/.claude.json" "$dst/.claude.json"
+    cp -RL "$HOME/.claude.json" "$(_profile_home_json "$dst")"
   fi
 }
 
@@ -228,7 +259,9 @@ _save_current_to() {
   # dir is empty and this comparison would wipe the freshly moved entries.
   for f in "$dst"/* "$dst"/.*; do
     base="$(basename "$f")"
-    if _skip_entry "$base" || [[ "$base" == ".claude.json" ]]; then
+    # The reserved home file is skipped here (handled below); a root
+    # .claude.json is now a genuine live-payload entry and propagates normally.
+    if _skip_entry "$base"; then
       continue
     fi
     if [[ ! -L "$f" && ! -e "$f" ]]; then
@@ -271,14 +304,16 @@ _save_current_to() {
   # the live copy, so the outgoing move leaves live COMPLETELY empty — a crash
   # at the save/load boundary then has nothing left for recovery to sweep into
   # the wrong profile (the load restores the target's own .claude.json).
+  local dst_home
+  dst_home="$(_profile_home_json "$dst")"
   if [[ -e "$HOME/.claude.json" ]]; then
-    rm -rf "${dst:?}/.claude.json"
-    cp -RL "$HOME/.claude.json" "$dst/.claude.json"
+    rm -rf "$dst_home"
+    cp -RL "$HOME/.claude.json" "$dst_home"
     if [[ "$move" == "--move" ]]; then
       rm -f "$HOME/.claude.json"
     fi
   else
-    rm -rf "${dst:?}/.claude.json"
+    rm -rf "$dst_home"
   fi
   _git_commit "$dst" "$msg"
 }
@@ -301,8 +336,10 @@ _sweep_live_entries_to() {
     fi
   done
   if [[ -e "$HOME/.claude.json" ]]; then
-    rm -rf "${dst:?}/.claude.json"
-    cp -RL "$HOME/.claude.json" "$dst/.claude.json"
+    local dst_home
+    dst_home="$(_profile_home_json "$dst")"
+    rm -rf "$dst_home"
+    cp -RL "$HOME/.claude.json" "$dst_home"
     rm -f "$HOME/.claude.json"
   fi
 }
@@ -416,6 +453,15 @@ _load_profile_to_live() {
   # it will be restored below. If not, absence is the correct state.
   rm -f "$HOME/.claude.json"
 
+  # Resolve the stored home file up front. For a legacy (pre-format-2) profile
+  # this may be the root .claude.json, which must then NOT also be loaded as a
+  # live payload entry.
+  local home_src legacy_root_home=""
+  home_src="$(_profile_home_json_read "$profile_dir")"
+  if [[ "$home_src" == "$profile_dir/.claude.json" ]]; then
+    legacy_root_home="yes"
+  fi
+
   # Copy/move profile contents to live locations
   for f in "$profile_dir"/* "$profile_dir"/.*; do
     local base
@@ -423,12 +469,8 @@ _load_profile_to_live() {
     if _skip_entry "$base"; then
       continue
     fi
-    # Handle .claude.json specially — goes to $HOME/.claude.json
-    # Always copy (never move) since .claude.json lives outside CLAUDE_DIR
-    if [[ "$base" == ".claude.json" ]]; then
-      if [[ -e "$f" && ! -L "$f" ]]; then
-        cp -RP "$f" "$HOME/.claude.json"
-      fi
+    # A legacy root .claude.json IS the home file — restored below, not here.
+    if [[ -n "$legacy_root_home" && "$base" == ".claude.json" ]]; then
       continue
     fi
     if [[ -e "$f" && ! -L "$f" ]]; then
@@ -439,6 +481,13 @@ _load_profile_to_live() {
       fi
     fi
   done
+
+  # Restore the home file to ~/.claude.json (always copy — it lives outside
+  # CLAUDE_DIR). The reserved-name storage keeps it separate from any live
+  # payload file literally named .claude.json.
+  if [[ -e "$home_src" && ! -L "$home_src" ]]; then
+    cp -RP "$home_src" "$HOME/.claude.json"
+  fi
 
   # Ensure CLAUDE_DIR exists after clearing
   mkdir -p "$CLAUDE_DIR"
@@ -477,6 +526,12 @@ _show_summary() {
     fi
     _show_summary_item "$f" "$base"
   done
+  # The home file is stored under a reserved name — surface it as .claude.json.
+  local home_src
+  home_src="$(_profile_home_json_read "$dir")"
+  if [[ -e "$home_src" ]]; then
+    _show_summary_item "$home_src" ".claude.json"
+  fi
 }
 
 # Print a summary of the active profile's live files. After `use --move`,

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -1,5 +1,25 @@
 # files.sh — Full-directory operations between live ~/.claude/ and profile directories
 
+# Gate every file/git mutation on a profile path. The clear/copy/rm loops
+# below follow whatever `$dst/*` expands to, so a profile root that is a
+# symlink (or otherwise resolves outside the store) would let `rm -rf` and
+# `mv` reach unrelated files. Refuse a symlinked leaf, and refuse anything that
+# does not canonically live within the store. Call BEFORE touching the path.
+_assert_profile_path_safe() {
+  local target="$1"
+  if [[ -L "$target" ]]; then
+    err "Refusing to operate on a symlinked profile path: $target"
+    exit 1
+  fi
+  local canon store
+  canon="$(_canonical_path "$target")"
+  store="$(_canonical_path "$PROFILES_DIR")"
+  if [[ "$canon" != "$store" && "$canon" != "$store"/* ]]; then
+    err "Refusing to operate outside the profile store: $target"
+    exit 1
+  fi
+}
+
 # Directory entries the tool never copies, moves, or deletes when syncing
 # between live ~/.claude/ and profile dirs:
 #   .  ..            directory self / parent
@@ -151,6 +171,7 @@ _ensure_target_parent() {
 # symlinked files are captured as regular files in the profile.
 _snapshot_current() {
   local dst="$1"
+  _assert_profile_path_safe "$dst"
   _assert_live_has_no_broken_symlinks || return 1
   # Copy everything from CLAUDE_DIR
   local f
@@ -178,6 +199,7 @@ _save_current_to() {
   local dst="$1"
   local msg="${2:-Auto-save}"
   local move="${3:-}"
+  _assert_profile_path_safe "$dst"
   mkdir -p "$dst"
   # An empty live state is never worth snapshotting — and after an
   # interrupted switch it is exactly the state that must not be allowed to
@@ -246,6 +268,7 @@ _save_current_to() {
 # to the profile they came from before any auto-save can absorb them.
 _sweep_live_entries_to() {
   local dst="$1" f base
+  _assert_profile_path_safe "$dst"
   mkdir -p "$dst"
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
     base="$(basename "$f")"
@@ -349,6 +372,10 @@ _validate_profile_for_load() {
 _load_profile_to_live() {
   local profile_dir="$1"
   local move="${2:-}"
+
+  # The source must be a real dir inside the store — never a symlink whose
+  # target we would copy into the live config.
+  _assert_profile_path_safe "$profile_dir"
 
   # Pre-validate
   _validate_profile_for_load "$profile_dir" || return 1

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -31,10 +31,16 @@ _assert_profile_path_safe() {
 # clear/summary loop runs through this predicate.
 _skip_entry() {
   case "$1" in
-    . | .. | .git | .gitignore | .saving.*) return 0 ;;
+    . | .. | .git | .gitignore) return 0 ;;
     *) return 1 ;;
   esac
 }
+
+# Where copy-mode saves stage each entry before atomically moving it into a
+# profile. It lives at the STORE root (a dotdir the store-level loops already
+# skip), not inside the profile payload — so a real user file named `.saving.*`
+# is captured normally instead of colliding with a staging temp.
+_staging_dir() { printf '%s\n' "$PROFILES_DIR/.saving"; }
 
 # True (0) when a profile directory holds any real entry (dotfiles included)
 # beyond the skipped git metadata.
@@ -210,8 +216,12 @@ _save_current_to() {
   if [[ "$move" != "--move" ]]; then
     _assert_live_has_no_broken_symlinks || return 1
   fi
-  # Clean temp entries left behind by an earlier interrupted copy
-  rm -rf "$dst"/.saving.* 2>/dev/null || true
+  # Clean any staging left behind by an earlier interrupted copy. Staging lives
+  # at the store root, so this never touches a real `.saving.*` file a user may
+  # keep inside their profile.
+  local staging
+  staging="$(_staging_dir)"
+  rm -rf "$staging" 2>/dev/null || true
   local f base
   # Deletions propagate: destination entries with no live counterpart go
   # away. This runs BEFORE the move/copy loop — after a --move pass the live
@@ -240,9 +250,12 @@ _save_current_to() {
       rm -rf "${dst:?}/$base"
       mv "$f" "$dst/$base"
     else
-      # Copy to a temp name first — the destination keeps its previous copy
-      # if the copy fails partway
-      local tmp="$dst/.saving.$base"
+      # Copy into store-root staging first (same filesystem as the profile, so
+      # the move is a rename) — the destination keeps its previous copy if the
+      # copy fails partway.
+      mkdir -p "$staging"
+      local tmp="$staging/$base"
+      rm -rf "$tmp"
       if ! cp -RL "$f" "$tmp"; then
         rm -rf "$tmp"
         err "Could not copy '$base' — profile keeps its previous copy"
@@ -252,6 +265,7 @@ _save_current_to() {
       mv "$tmp" "$dst/$base"
     fi
   done
+  rm -rf "$staging" 2>/dev/null || true
   # Special: always copy ~/.claude.json (even with --move, since it lives
   # outside CLAUDE_DIR); its deletion propagates too
   if [[ -e "$HOME/.claude.json" ]]; then

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -11,9 +11,46 @@
 # clear/summary loop runs through this predicate.
 _skip_entry() {
   case "$1" in
-    . | .. | .git | .gitignore) return 0 ;;
+    . | .. | .git | .gitignore | .saving.*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# True (0) when a profile directory holds any real entry (dotfiles included)
+# beyond the skipped git metadata.
+_dir_has_entries() {
+  local dir="$1" f base
+  for f in "$dir"/* "$dir"/.*; do
+    base="$(basename "$f")"
+    if _skip_entry "$base"; then
+      continue
+    fi
+    if [[ -L "$f" || -e "$f" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Refuse to snapshot a live state containing dangling symlinks: cp -RL cannot
+# copy them, and silently dropping them would make the snapshot lie.
+_assert_live_has_no_broken_symlinks() {
+  local f base broken
+  for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.* "$HOME/.claude.json"; do
+    base="$(basename "$f")"
+    if [[ "$f" != "$HOME/.claude.json" ]] && _skip_entry "$base"; then
+      continue
+    fi
+    if [[ ! -L "$f" && ! -e "$f" ]]; then
+      continue
+    fi
+    broken="$(find "$f" \( -type l ! -exec test -e {} \; \) -print 2>/dev/null | head -1 || true)"
+    if [[ -n "$broken" ]]; then
+      err "Broken symlink in live config: $broken"
+      err "Fix or remove it, then re-run"
+      return 1
+    fi
+  done
 }
 
 # True (0) when the live state holds anything a load would destroy:
@@ -114,6 +151,7 @@ _ensure_target_parent() {
 # symlinked files are captured as regular files in the profile.
 _snapshot_current() {
   local dst="$1"
+  _assert_live_has_no_broken_symlinks || return 1
   # Copy everything from CLAUDE_DIR
   local f
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
@@ -134,33 +172,96 @@ _snapshot_current() {
 
 # Copy live state into a profile directory and commit changes.
 # With --move, items are moved instead of copied (used during switch).
+# The result is an exact snapshot: entries the live state no longer has are
+# removed from the destination, so deletions don't resurrect on the next load.
 _save_current_to() {
   local dst="$1"
   local msg="${2:-Auto-save}"
   local move="${3:-}"
   mkdir -p "$dst"
-  local f
+  # An empty live state is never worth snapshotting — and after an
+  # interrupted switch it is exactly the state that must not be allowed to
+  # propagate deletions into a profile that still holds everything.
+  if ! _live_state_nonempty; then
+    return 0
+  fi
+  if [[ "$move" != "--move" ]]; then
+    _assert_live_has_no_broken_symlinks || return 1
+  fi
+  # Clean temp entries left behind by an earlier interrupted copy
+  rm -rf "$dst"/.saving.* 2>/dev/null || true
+  local f base
+  # Deletions propagate: destination entries with no live counterpart go
+  # away. This runs BEFORE the move/copy loop — after a --move pass the live
+  # dir is empty and this comparison would wipe the freshly moved entries.
+  for f in "$dst"/* "$dst"/.*; do
+    base="$(basename "$f")"
+    if _skip_entry "$base" || [[ "$base" == ".claude.json" ]]; then
+      continue
+    fi
+    if [[ ! -L "$f" && ! -e "$f" ]]; then
+      continue
+    fi
+    if [[ ! -L "$CLAUDE_DIR/$base" && ! -e "$CLAUDE_DIR/$base" ]]; then
+      rm -rf "$f"
+    fi
+  done
   for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
-    local base
     base="$(basename "$f")"
     if _skip_entry "$base"; then
       continue
     fi
-    if [[ -e "$f" ]]; then
-      rm -rf "$dst/$base"
-      if [[ "$move" == "--move" ]]; then
-        mv "$f" "$dst/$base"
-      else
-        cp -RL "$f" "$dst/$base"
+    if [[ ! -L "$f" && ! -e "$f" ]]; then
+      continue
+    fi
+    if [[ "$move" == "--move" ]]; then
+      rm -rf "${dst:?}/$base"
+      mv "$f" "$dst/$base"
+    else
+      # Copy to a temp name first — the destination keeps its previous copy
+      # if the copy fails partway
+      local tmp="$dst/.saving.$base"
+      if ! cp -RL "$f" "$tmp"; then
+        rm -rf "$tmp"
+        err "Could not copy '$base' — profile keeps its previous copy"
+        return 1
       fi
+      rm -rf "${dst:?}/$base"
+      mv "$tmp" "$dst/$base"
     fi
   done
-  # Special: always copy ~/.claude.json (even with --move, since it lives outside CLAUDE_DIR)
+  # Special: always copy ~/.claude.json (even with --move, since it lives
+  # outside CLAUDE_DIR); its deletion propagates too
   if [[ -e "$HOME/.claude.json" ]]; then
-    rm -rf "$dst/.claude.json"
+    rm -rf "${dst:?}/.claude.json"
     cp -RL "$HOME/.claude.json" "$dst/.claude.json"
+  else
+    rm -rf "${dst:?}/.claude.json"
   fi
   _git_commit "$dst" "$msg"
+}
+
+# Move live entries into a profile directory WITHOUT removing anything else
+# there and without touching git. Used to return a half-moved switch's files
+# to the profile they came from before any auto-save can absorb them.
+_sweep_live_entries_to() {
+  local dst="$1" f base
+  mkdir -p "$dst"
+  for f in "$CLAUDE_DIR"/* "$CLAUDE_DIR"/.*; do
+    base="$(basename "$f")"
+    if _skip_entry "$base"; then
+      continue
+    fi
+    if [[ -L "$f" || -e "$f" ]]; then
+      rm -rf "${dst:?}/$base"
+      mv "$f" "$dst/$base"
+    fi
+  done
+  if [[ -e "$HOME/.claude.json" ]]; then
+    rm -rf "${dst:?}/.claude.json"
+    cp -RL "$HOME/.claude.json" "$dst/.claude.json"
+    rm -f "$HOME/.claude.json"
+  fi
 }
 
 # Auto-repair symlinks left by older save code (which used cp -RH instead of cp -RL).
@@ -172,7 +273,7 @@ _repair_profile_symlinks() {
   while IFS= read -r -d '' symlink; do
     # Broken symlink: -L is true but -e is false
     if [[ ! -e "$symlink" ]]; then
-      err "Broken symlink in profile — aborting switch (live files untouched)"
+      err "Broken symlink in profile: $symlink — aborting switch (live files untouched)"
       return 1
     fi
     # Replace symlink with dereferenced copy
@@ -226,6 +327,15 @@ _validate_profile_for_load() {
           err "Symlink found in $f — aborting switch (live files untouched)"
           return 1
         fi
+        # Unreadable files nested in readable dirs would kill a copy-based
+        # load after the live state is already cleared — reject up front
+        local nested_file
+        while IFS= read -r -d '' nested_file; do
+          if [[ ! -r "$nested_file" ]]; then
+            err "Unreadable file '$nested_file' in profile — aborting switch (live files untouched)"
+            return 1
+          fi
+        done < <(find "$f" -type f -print0 2>/dev/null)
       elif [[ -f "$f" && ! -r "$f" ]]; then
         err "Unreadable file '$base' in profile — aborting switch (live files untouched)"
         return 1

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -1,13 +1,23 @@
 # git.sh — Git history tracking for profile directories
 
+_git_history_warn() {
+  local dir="$1" why="$2"
+  warn "Could not record history for '$(basename "$dir")' ($why) — files saved, history skipped"
+}
+
 _git_init() {
   local dir="$1"
   if [[ ! -d "$dir/.git" ]]; then
     # Static gitignore — keeps git fast (only small config files tracked)
     echo "$GITIGNORE_CONTENT" > "$dir/.gitignore"
     git -C "$dir" init -q
-    git -C "$dir" add -A
-    git -C "$dir" commit -q -m "Profile created" --allow-empty 2>/dev/null || true
+    if ! git -C "$dir" add -A 2>/dev/null; then
+      _git_history_warn "$dir" "git add failed"
+      return 0
+    fi
+    if ! git -C "$dir" commit -q -m "Profile created" --allow-empty 2>/dev/null; then
+      _git_history_warn "$dir" "git commit failed — is your git identity configured?"
+    fi
   fi
 }
 
@@ -15,9 +25,14 @@ _git_commit() {
   local dir="$1"
   local msg="${2:-Save}"
   [[ -d "$dir/.git" ]] || _git_init "$dir"
-  git -C "$dir" add -A
+  if ! git -C "$dir" add -A 2>/dev/null; then
+    _git_history_warn "$dir" "git add failed"
+    return 0
+  fi
   if ! git -C "$dir" diff --cached --quiet 2>/dev/null; then
-    git -C "$dir" commit -q -m "$msg" 2>/dev/null || true
+    if ! git -C "$dir" commit -q -m "$msg" 2>/dev/null; then
+      _git_history_warn "$dir" "git commit failed — is your git identity configured?"
+    fi
   fi
 }
 

--- a/lib/state.sh
+++ b/lib/state.sh
@@ -22,7 +22,9 @@ get_current_validated() {
     return
   fi
   if [[ "$name" =~ [^a-zA-Z0-9._-] || "$name" == ..* || "$name" == .* || "$name" == -* ]]; then
-    err ".current file is corrupt (invalid profile name: '$name')."
+    local display
+    display="$(printf '%s' "$name" | tr -d '[:cntrl:]')"
+    err ".current file is corrupt (invalid profile name: '$display')."
     err "Run 'claude-profile list' to see available profiles, then 'claude-profile use <name>' to recover."
     exit 1
   fi
@@ -32,14 +34,89 @@ get_current_validated() {
 set_current() { echo "$1" > "$CURRENT_FILE"; }
 clear_current() { rm -f "$CURRENT_FILE"; }
 
+# ─── Exclusive lock for mutating commands ───────────────────
+# Concurrent invocations interleave rm/mv on the same live files; with --move
+# semantics that can destroy the sole copy of a profile's data.
+
+_release_lock() { rm -rf "$PROFILES_DIR/.lock"; }
+
+_acquire_lock() {
+  ensure_dir
+  local lock="$PROFILES_DIR/.lock"
+  if ! mkdir "$lock" 2>/dev/null; then
+    local pid
+    pid="$(cat "$lock/pid" 2>/dev/null || true)"
+    if [[ -z "$pid" ]]; then
+      # The other process may be between mkdir and writing its pid
+      sleep 0.2
+      pid="$(cat "$lock/pid" 2>/dev/null || true)"
+    fi
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      err "Another claude-profile operation is in progress (pid $pid)"
+      err "If that is wrong, remove $lock"
+      exit 1
+    fi
+    # Stale lock from a dead process — take it over
+    rm -rf "$lock"
+    if ! mkdir "$lock" 2>/dev/null; then
+      err "Another claude-profile operation is in progress"
+      exit 1
+    fi
+  fi
+  echo "$$" > "$lock/pid"
+  trap _release_lock EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+}
+
+# ─── Interrupted-operation marker ────────────────────────────
+# Written around the destructive phase of use/deactivate and removed only on
+# success — a crash leaves it behind so the next run can recover instead of
+# auto-saving a half-switched live state into the wrong profile.
+
+_set_op_marker()   { echo "$1" > "$OP_MARKER_FILE"; }
+_clear_op_marker() { rm -f "$OP_MARKER_FILE"; }
+_get_op_marker() {
+  if [[ -f "$OP_MARKER_FILE" ]]; then
+    cat "$OP_MARKER_FILE"
+  else
+    echo ""
+  fi
+}
+
+_refuse_if_op_interrupted() {
+  local op
+  op="$(_get_op_marker)"
+  if [[ -z "$op" ]]; then
+    return 0
+  fi
+  if [[ "$op" == "use "* ]]; then
+    err "A previous switch to '${op#use }' was interrupted"
+    err "Run 'claude-profile use ${op#use }' to recover first"
+  elif [[ "$op" == "deactivate" ]]; then
+    err "A previous deactivate was interrupted"
+    err "Run 'claude-profile deactivate' to complete it first"
+  else
+    err "An interrupted operation left a marker — inspect and remove $OP_MARKER_FILE manually"
+  fi
+  exit 1
+}
+
 # Back up original ~/.claude/ state once, before first use.
 # The backup is never modified — it's the "main branch".
+# The snapshot lands in a temp dir first: a snapshot that dies partway must
+# never leave a half-written directory that later runs accept as the backup.
 _backup_raw_state() {
   local backup_dir="$PROFILES_DIR/.pre-profiles-backup"
-  [[ -d "$backup_dir" ]] && return
-  mkdir -p "$backup_dir"
+  if [[ -d "$backup_dir" ]]; then
+    return 0
+  fi
+  local tmp="$backup_dir.tmp"
+  rm -rf "$tmp"
+  mkdir -p "$tmp"
   info "Backing up original state..."
-  _snapshot_current "$backup_dir"
+  _snapshot_current "$tmp"
+  mv "$tmp" "$backup_dir"
 }
 
 _ensure_seed_dir() {

--- a/lib/state.sh
+++ b/lib/state.sh
@@ -44,16 +44,39 @@ clear_current() { rm -f "$CURRENT_FILE"; }
 # Concurrent invocations interleave rm/mv on the same live files; with --move
 # semantics that can destroy the sole copy of a profile's data.
 
-_release_lock() { rm -rf "$PROFILES_DIR/.lock"; }
+# A per-process ownership token, written into the lock when we claim it. Only
+# a matching token releases the lock — a process that lost a takeover race must
+# never delete the new owner's lock on EXIT.
+_LOCK_TOKEN=""
+
+_release_lock() {
+  local lock="$PROFILES_DIR/.lock"
+  if [[ -n "$_LOCK_TOKEN" && "$(cat "$lock/token" 2>/dev/null || true)" == "$_LOCK_TOKEN" ]]; then
+    rm -rf "$lock"
+  fi
+}
 
 _acquire_lock() {
   ensure_dir
   local lock="$PROFILES_DIR/.lock"
-  if ! mkdir "$lock" 2>/dev/null; then
+  _LOCK_TOKEN="$$-${RANDOM}${RANDOM}"
+
+  local attempt
+  for attempt in 1 2 3; do
+    if mkdir "$lock" 2>/dev/null; then
+      echo "$$" > "$lock/pid"
+      printf '%s\n' "$_LOCK_TOKEN" > "$lock/token"
+      trap _release_lock EXIT
+      trap 'exit 130' INT
+      trap 'exit 143' TERM
+      return 0
+    fi
+
+    # Lock exists — is its owner still alive?
     local pid
     pid="$(cat "$lock/pid" 2>/dev/null || true)"
     if [[ -z "$pid" ]]; then
-      # The other process may be between mkdir and writing its pid
+      # The owner may be between mkdir and writing its pid
       sleep 0.2
       pid="$(cat "$lock/pid" 2>/dev/null || true)"
     fi
@@ -62,17 +85,31 @@ _acquire_lock() {
       err "If that is wrong, remove $lock"
       exit 1
     fi
-    # Stale lock from a dead process — take it over
-    rm -rf "$lock"
-    if ! mkdir "$lock" 2>/dev/null; then
-      err "Another claude-profile operation is in progress"
-      exit 1
+
+    # Stale lock from a dead owner. Claim the takeover atomically: rename the
+    # exact stale directory aside. `rename` on a single source succeeds for
+    # only one racer, so two contenders can't both clear the same lock and
+    # proceed. If our rename lost (another racer already took over, or the
+    # owner revived and the lock is now a live one), fall through to retry —
+    # the next mkdir fails and the liveness check reports "in progress".
+    local stash="$lock.stale.$$.$attempt"
+    if mv "$lock" "$stash" 2>/dev/null; then
+      # Guard the exotic case where we grabbed a *fresh* lock from a racer that
+      # already took over: if its owner is alive, restore it and stand down.
+      local spid
+      spid="$(cat "$stash/pid" 2>/dev/null || true)"
+      if [[ "$spid" =~ ^[0-9]+$ ]] && kill -0 "$spid" 2>/dev/null; then
+        mv "$stash" "$lock" 2>/dev/null || rm -rf "$stash"
+        err "Another claude-profile operation is in progress"
+        exit 1
+      fi
+      rm -rf "$stash"
     fi
-  fi
-  echo "$$" > "$lock/pid"
-  trap _release_lock EXIT
-  trap 'exit 130' INT
-  trap 'exit 143' TERM
+    # loop and retry mkdir
+  done
+
+  err "Another claude-profile operation is in progress"
+  exit 1
 }
 
 # ─── Interrupted-operation marker ────────────────────────────

--- a/lib/state.sh
+++ b/lib/state.sh
@@ -1,6 +1,12 @@
 # state.sh — Profile state: current profile, backup, directory management
 
-ensure_dir() { mkdir -p "$PROFILES_DIR"; }
+ensure_dir() {
+  mkdir -p "$PROFILES_DIR"
+  # Tighten the store root even if an older run (or install) created it with a
+  # looser umask — a 0700 root blocks other local users from traversing to the
+  # Git objects inside, which git itself writes group/world-readable.
+  chmod 700 "$PROFILES_DIR" 2>/dev/null || true
+}
 
 get_current() {
   if [[ -f "$CURRENT_FILE" ]]; then

--- a/lib/state.sh
+++ b/lib/state.sh
@@ -234,6 +234,49 @@ _ensure_seed_dir() {
   done
 }
 
+# ─── Store format migration ─────────────────────────────────
+# Bring an existing store up to the current on-disk format. Idempotent: a
+# format stamp records the last-applied version so this runs once per upgrade.
+#
+# Format 2: the home-level ~/.claude.json moved from a profile's root
+# ".claude.json" (which collided with a live file of the same name) to the
+# reserved CLAUDE_HOME_JSON name. The load path also tolerates the old layout,
+# so a store that misses this migration still loads correctly.
+_migrate_profile_to_format2() {
+  local dir="$1"
+  if [[ -e "$dir/.claude.json" && ! -d "$dir/.claude.json" && ! -e "$dir/$CLAUDE_HOME_JSON" ]]; then
+    mv "$dir/.claude.json" "$dir/$CLAUDE_HOME_JSON"
+    if [[ -d "$dir/.git" ]]; then
+      _git_commit "$dir" "Store home file under a reserved name" 2>/dev/null || true
+    fi
+  fi
+}
+
+_migrate_store_format() {
+  [[ -d "$PROFILES_DIR" ]] || return 0
+  local current=0
+  if [[ -f "$STORE_FORMAT_FILE" ]]; then
+    current="$(cat "$STORE_FORMAT_FILE" 2>/dev/null || echo 0)"
+  fi
+  [[ "$current" =~ ^[0-9]+$ ]] || current=0
+  if [[ "$current" -ge "$STORE_FORMAT" ]]; then
+    return 0
+  fi
+
+  local dir base
+  for dir in "$PROFILES_DIR"/* "$PROFILES_DIR/.pre-profiles-backup"; do
+    [[ -d "$dir" ]] || continue
+    base="$(basename "$dir")"
+    # Only real profiles and the backup — skip store metadata (.seed, .lock, …)
+    if [[ "$base" == .* && "$base" != ".pre-profiles-backup" ]]; then
+      continue
+    fi
+    _migrate_profile_to_format2 "$dir"
+  done
+
+  printf '%s\n' "$STORE_FORMAT" > "$STORE_FORMAT_FILE"
+}
+
 _ensure_original_backup() {
   ensure_dir
   _backup_raw_state

--- a/lib/state.sh
+++ b/lib/state.sh
@@ -245,7 +245,7 @@ _ensure_seed_dir() {
 _migrate_profile_to_format2() {
   local dir="$1"
   if [[ -e "$dir/.claude.json" && ! -d "$dir/.claude.json" && ! -e "$dir/$CLAUDE_HOME_JSON" ]]; then
-    mv "$dir/.claude.json" "$dir/$CLAUDE_HOME_JSON"
+    mv "$dir/.claude.json" "$dir/$CLAUDE_HOME_JSON" 2>/dev/null || return 1
     if [[ -d "$dir/.git" ]]; then
       _git_commit "$dir" "Store home file under a reserved name" 2>/dev/null || true
     fi
@@ -271,7 +271,9 @@ _migrate_store_format() {
     if [[ "$base" == .* && "$base" != ".pre-profiles-backup" ]]; then
       continue
     fi
-    _migrate_profile_to_format2 "$dir"
+    # Best-effort per profile: an un-migratable dir (odd perms, etc.) falls back
+    # to the tolerant load path rather than blocking the rest.
+    _migrate_profile_to_format2 "$dir" || true
   done
 
   printf '%s\n' "$STORE_FORMAT" > "$STORE_FORMAT_FILE"

--- a/lib/state.sh
+++ b/lib/state.sh
@@ -113,12 +113,41 @@ _acquire_lock() {
 }
 
 # ─── Interrupted-operation marker ────────────────────────────
-# Written around the destructive phase of use/deactivate and removed only on
-# success — a crash leaves it behind so the next run can recover instead of
-# auto-saving a half-switched live state into the wrong profile.
+# Bracket the destructive phase of use/new/restore/deactivate. The marker
+# records the operation, its PHASE, and the source/target profiles so a crash
+# is recovered by sweeping the half-moved live state back to the RIGHT profile:
+#   phase=saving   — crashed during the outgoing --move; live holds a partial
+#                    copy of SOURCE, so recovery sweeps it back to source.
+#   phase=loading  — crashed during the incoming load; live holds a partial
+#                    copy of TARGET, so recovery sweeps it back to target.
+#   phase=restore  — deactivate crashed mid-restore; live holds a partial copy
+#                    of the backup (handled by deactivate itself).
+# Written as key=value lines. The old single-line forms ("use X",
+# "deactivate") are still parsed so a marker left by an older binary recovers
+# instead of crashing.
 
-_set_op_marker()   { echo "$1" > "$OP_MARKER_FILE"; }
+_mark_op() {
+  local op="$1" phase="$2" source="$3" target="$4"
+  {
+    printf 'op=%s\n' "$op"
+    printf 'phase=%s\n' "$phase"
+    printf 'source=%s\n' "$source"
+    printf 'target=%s\n' "$target"
+  } > "$OP_MARKER_FILE"
+}
+
+# Back-compat single-arg writer for loading-only callers (edit/restore reload,
+# and any old call sites): "use X" → loading phase to X; "deactivate" → restore.
+_set_op_marker() {
+  case "$1" in
+    "use "*)    _mark_op use loading "" "${1#use }" ;;
+    deactivate) _mark_op deactivate restore "" "" ;;
+    *)          _mark_op "$1" "" "" "" ;;
+  esac
+}
+
 _clear_op_marker() { rm -f "$OP_MARKER_FILE"; }
+
 _get_op_marker() {
   if [[ -f "$OP_MARKER_FILE" ]]; then
     cat "$OP_MARKER_FILE"
@@ -127,21 +156,54 @@ _get_op_marker() {
   fi
 }
 
-_refuse_if_op_interrupted() {
-  local op
-  op="$(_get_op_marker)"
-  if [[ -z "$op" ]]; then
-    return 0
-  fi
-  if [[ "$op" == "use "* ]]; then
-    err "A previous switch to '${op#use }' was interrupted"
-    err "Run 'claude-profile use ${op#use }' to recover first"
-  elif [[ "$op" == "deactivate" ]]; then
-    err "A previous deactivate was interrupted"
-    err "Run 'claude-profile deactivate' to complete it first"
+# Parse the marker into globals _OP _OP_PHASE _OP_SOURCE _OP_TARGET, tolerating
+# the old single-line forms. Returns 1 (all empty) when no marker exists.
+_parse_op_marker() {
+  _OP="" _OP_PHASE="" _OP_SOURCE="" _OP_TARGET=""
+  [[ -f "$OP_MARKER_FILE" ]] || return 1
+  local first line
+  first="$(head -1 "$OP_MARKER_FILE" 2>/dev/null || true)"
+  if [[ "$first" == op=* ]]; then
+    while IFS= read -r line; do
+      case "$line" in
+        op=*)     _OP="${line#op=}" ;;
+        phase=*)  _OP_PHASE="${line#phase=}" ;;
+        source=*) _OP_SOURCE="${line#source=}" ;;
+        target=*) _OP_TARGET="${line#target=}" ;;
+      esac
+    done < "$OP_MARKER_FILE"
+  elif [[ "$first" == "use "* ]]; then
+    _OP="use"; _OP_PHASE="loading"; _OP_TARGET="${first#use }"
+  elif [[ "$first" == "deactivate" ]]; then
+    _OP="deactivate"; _OP_PHASE="restore"
   else
-    err "An interrupted operation left a marker — inspect and remove $OP_MARKER_FILE manually"
+    _OP="unknown"
   fi
+  return 0
+}
+
+_refuse_if_op_interrupted() {
+  _parse_op_marker || return 0
+  case "$_OP" in
+    use)
+      local t
+      if [[ "$_OP_PHASE" == "saving" ]]; then
+        t="$_OP_SOURCE"
+      else
+        t="$_OP_TARGET"
+      fi
+      [[ -z "$t" ]] && t="${_OP_TARGET:-$_OP_SOURCE}"
+      err "A previous switch (to '$t') was interrupted"
+      err "Run 'claude-profile use $t' to recover first"
+      ;;
+    deactivate)
+      err "A previous deactivate was interrupted"
+      err "Run 'claude-profile deactivate' to complete it first"
+      ;;
+    *)
+      err "An interrupted operation left a marker — inspect and remove $OP_MARKER_FILE manually"
+      ;;
+  esac
   exit 1
 }
 

--- a/remote-install.sh
+++ b/remote-install.sh
@@ -3,10 +3,17 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/yarikleto/claude-profile/main/remote-install.sh | bash
 set -euo pipefail
 
-REPO="https://github.com/yarikleto/claude-profile.git"
-CLONE_DIR="$(mktemp -d)"
-trap 'rm -rf "$CLONE_DIR"' EXIT
+# The body runs only from the final line — a truncated download defines an
+# incomplete function (syntax error) instead of executing a script prefix.
+main() {
+  local repo="${CLAUDE_PROFILE_REPO:-https://github.com/yarikleto/claude-profile.git}"
+  # Not local — the EXIT trap fires after main returns
+  CLONE_DIR="$(mktemp -d)"
+  trap 'rm -rf "$CLONE_DIR"' EXIT
 
-echo "Installing claude-profile..."
-git clone --depth 1 "$REPO" "$CLONE_DIR/claude-profile" 2>/dev/null
-bash "$CLONE_DIR/claude-profile/install.sh"
+  echo "Installing claude-profile..."
+  git clone -q --depth 1 "$repo" "$CLONE_DIR/claude-profile"
+  bash "$CLONE_DIR/claude-profile/install.sh"
+}
+
+main "$@"

--- a/tests/claude_json_namespace.bats
+++ b/tests/claude_json_namespace.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+load test_helper
+
+# The home-level ~/.claude.json and a live file literally named
+# ~/.claude/.claude.json must occupy disjoint namespaces in a profile, so a
+# round trip preserves both.
+
+@test "namespace: a live ~/.claude/.claude.json survives alongside the home file" {
+  echo '{"home":"OUTER"}' > "$HOME/.claude.json"
+  echo '{"inner":"INNER"}' > "$CLAUDE_CODE_HOME/.claude.json"
+
+  run_cli_ok fork p1
+  run_cli_ok new p2
+  run_cli_ok use p1
+
+  # Both files come back intact and distinct
+  grep -q '"home":"OUTER"' "$HOME/.claude.json"
+  grep -q '"inner":"INNER"' "$CLAUDE_CODE_HOME/.claude.json"
+}
+
+@test "namespace: the home file still round-trips when there is no inner file" {
+  echo '{"home":"ONLY"}' > "$HOME/.claude.json"
+  rm -f "$CLAUDE_CODE_HOME/.claude.json"
+
+  run_cli_ok fork p1
+  run_cli_ok new p2
+  run_cli_ok use p1
+
+  grep -q '"home":"ONLY"' "$HOME/.claude.json"
+  [ ! -e "$CLAUDE_CODE_HOME/.claude.json" ]
+}
+
+@test "namespace: fork stores the home file outside the live payload" {
+  echo '{"home":"OUTER"}' > "$HOME/.claude.json"
+  echo '{"inner":"INNER"}' > "$CLAUDE_CODE_HOME/.claude.json"
+  run_cli_ok fork p1
+
+  # The two files are stored under different paths (no collision)
+  run bash -c "grep -rl 'OUTER' '$(profile_dir p1)'"
+  local home_path="$output"
+  run bash -c "grep -rl 'INNER' '$(profile_dir p1)'"
+  local inner_path="$output"
+  [ -n "$home_path" ]
+  [ -n "$inner_path" ]
+  [ "$home_path" != "$inner_path" ]
+}
+
+@test "namespace: migrates a legacy profile that stored the home file at the root" {
+  run_cli_ok fork legacy
+  run_cli_ok new other        # switch away so 'legacy' is a full stored profile
+
+  # Force the pre-format-2 on-disk layout: home file at the profile root, no
+  # reserved file, and no format stamp (so the next run migrates).
+  rm -f "$(profile_dir legacy)/.claude-profile-home.json"
+  echo '{"home":"LEGACY"}' > "$(profile_dir legacy)/.claude.json"
+  rm -f "$CLAUDE_PROFILE_HOME/.format"
+
+  # A switch to the legacy profile must restore its home file, not lose it
+  run_cli_ok use legacy
+  grep -q '"home":"LEGACY"' "$HOME/.claude.json"
+  # It must NOT have been loaded as a live-payload file
+  [ ! -e "$CLAUDE_CODE_HOME/.claude.json" ]
+  # And the store is now migrated: home file at the reserved name
+  [ -f "$(profile_dir legacy)/.claude-profile-home.json" ]
+}

--- a/tests/current.bats
+++ b/tests/current.bats
@@ -14,3 +14,13 @@ load test_helper
   [ "$status" -eq 0 ]
   [[ "$output" == "default" ]]
 }
+
+@test "current: corrupt .current fails cleanly without echoing raw bytes" {
+  mkdir -p "$CLAUDE_PROFILE_HOME"
+  printf '../evil\033]0;pwned\007' > "$CLAUDE_PROFILE_HOME/.current"
+
+  run_cli current
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"corrupt"* ]] || [[ "$output" == *"invalid"* ]]
+  [[ "$output" != *$'\033'* ]]
+}

--- a/tests/data_safety.bats
+++ b/tests/data_safety.bats
@@ -750,3 +750,28 @@ JSON
   [[ "$log" == *"my personal config"* ]]
   [[ "$log" != *"Profile created"* ]]
 }
+
+@test "backup: failed first snapshot is not accepted as the original backup" {
+  # Nested dangling symlink makes the first snapshot fail
+  ln -s "$BATS_TEST_TMPDIR/gone" "$CLAUDE_CODE_HOME/agents/broken"
+
+  run_cli fork first
+  [ "$status" -ne 0 ]
+  # A half-written directory must never pass for the sacred backup
+  [ ! -d "$(backup_dir)" ]
+
+  # After the user fixes the problem, a re-run creates a COMPLETE backup
+  rm "$CLAUDE_CODE_HOME/agents/broken"
+  run_cli_ok fork second
+  [ -f "$(backup_dir)/settings.json" ]
+  [ -f "$(backup_dir)/.claude.json" ]
+  [ -d "$(backup_dir)/skills" ]
+}
+
+@test "fork: fails loudly instead of silently dropping a dangling symlink" {
+  ln -s "$BATS_TEST_TMPDIR/gone" "$CLAUDE_CODE_HOME/dangling"
+
+  run_cli fork snap
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"symlink"* ]] || [[ "$output" == *"Symlink"* ]]
+}

--- a/tests/data_safety.bats
+++ b/tests/data_safety.bats
@@ -85,7 +85,7 @@ load test_helper
   grep -q "Alpha CLAUDE.md" "$alpha_dir/CLAUDE.md"
   grep -q "alpha-agent" "$alpha_dir/agents/myagent.md"
   grep -q '"alpha"' "$alpha_dir/keybindings.json"
-  grep -q '"alpha"' "$alpha_dir/.claude.json"
+  grep -q '"alpha"' "$alpha_dir/.claude-profile-home.json"
 }
 
 @test "use: switching back restores all managed files" {
@@ -240,7 +240,7 @@ load test_helper
 
   [ -f "$(profile_dir rescued)/skills/precious/SKILL.md" ]
   grep -q "irreplaceable" "$(profile_dir rescued)/skills/precious/SKILL.md"
-  grep -q "precious-server" "$(profile_dir rescued)/.claude.json"
+  grep -q "precious-server" "$(profile_dir rescued)/.claude-profile-home.json"
 }
 
 @test "use: proceeds without --force when detached live state is empty" {
@@ -414,7 +414,7 @@ load test_helper
   [ "$backed_settings" = "$original_settings" ]
 
   local backed_mcp
-  backed_mcp="$(cat "$backup/.claude.json")"
+  backed_mcp="$(cat "$backup/.claude-profile-home.json")"
   [ "$backed_mcp" = "$original_mcp" ]
 }
 
@@ -764,7 +764,7 @@ JSON
   rm "$CLAUDE_CODE_HOME/agents/broken"
   run_cli_ok fork second
   [ -f "$(backup_dir)/settings.json" ]
-  [ -f "$(backup_dir)/.claude.json" ]
+  [ -f "$(backup_dir)/.claude-profile-home.json" ]
   [ -d "$(backup_dir)/skills" ]
 }
 

--- a/tests/deactivate.bats
+++ b/tests/deactivate.bats
@@ -132,6 +132,30 @@ load test_helper
   grep -q '"v2"' "$(profile_dir default)/settings.json"
 }
 
+@test "deactivate: recovers a deactivate interrupted during its outgoing save" {
+  echo '{"who":"ORIGINAL"}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok fork base       # first command captures the backup = ORIGINAL
+  echo '{"who":"P"}' > "$CLAUDE_CODE_HOME/settings.json"
+  mkdir -p "$CLAUDE_CODE_HOME/agents"
+  echo 'AGENT-P' > "$CLAUDE_CODE_HOME/agents/a.md"
+  run_cli_ok fork P          # P active with {who:P}
+
+  # Simulate deactivate dying mid outgoing-save of P: settings.json already
+  # moved into P's profile and gone from live, agents/ not yet moved. The
+  # saving-phase marker was written before the first destructive move.
+  mv "$CLAUDE_CODE_HOME/settings.json" "$(profile_dir P)/settings.json"
+  printf 'op=deactivate\nphase=saving\nsource=P\ntarget=\n' > "$CLAUDE_PROFILE_HOME/.op-in-progress"
+
+  run_cli deactivate
+  [ "$status" -eq 0 ]
+  # P kept its sole copy — not exact-sync-deleted
+  grep -q '"who":"P"' "$(profile_dir P)/settings.json"
+  grep -q 'AGENT-P' "$(profile_dir P)/agents/a.md"
+  # Original state restored and detached
+  grep -q '"who":"ORIGINAL"' "$CLAUDE_CODE_HOME/settings.json"
+  [ ! -f "$CLAUDE_PROFILE_HOME/.current" ]
+}
+
 @test "deactivate: refuses while a switch is interrupted" {
   run_cli_ok fork default
   echo "use default" > "$CLAUDE_PROFILE_HOME/.op-in-progress"

--- a/tests/deactivate.bats
+++ b/tests/deactivate.bats
@@ -94,6 +94,53 @@ load test_helper
   [ -z "$(find "$CLAUDE_PROFILE_HOME" -mindepth 1 -maxdepth 1 -type d -name 'detached-*')" ]
 }
 
+@test "deactivate: unreadable file nested in backup aborts before live state is touched" {
+  run_cli_ok fork default
+  mkdir -p "$(backup_dir)/skills/deep"
+  echo '{}' > "$(backup_dir)/skills/deep/locked.json"
+  chmod 000 "$(backup_dir)/skills/deep/locked.json"
+  echo '{"live_marker": true}' > "$CLAUDE_CODE_HOME/settings.json"
+
+  run_cli deactivate
+  local st="$status"
+  chmod 644 "$(backup_dir)/skills/deep/locked.json"
+
+  [ "$st" -ne 0 ]
+  # live state untouched
+  grep -q '"live_marker"' "$CLAUDE_CODE_HOME/settings.json"
+  [ -f "$HOME/.claude.json" ]
+}
+
+@test "deactivate: completes an interrupted restore without corrupting the profile" {
+  run_cli_ok fork default
+  echo '{"v2": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok save -m v2
+
+  # Simulate deactivate dying after its auto-save, mid-restore:
+  # live already moved out, backup partially copied back in
+  find "$CLAUDE_CODE_HOME" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+  rm -f "$HOME/.claude.json"
+  cp "$(backup_dir)/settings.json" "$CLAUDE_CODE_HOME/settings.json"
+  echo "deactivate" > "$CLAUDE_PROFILE_HOME/.op-in-progress"
+
+  run_cli deactivate
+  [ "$status" -eq 0 ]
+  grep -q '"effortLevel"' "$CLAUDE_CODE_HOME/settings.json"
+  [ -f "$HOME/.claude.json" ]
+  [ ! -f "$CLAUDE_PROFILE_HOME/.current" ]
+  # profile kept its own content — not polluted by the partial restore
+  grep -q '"v2"' "$(profile_dir default)/settings.json"
+}
+
+@test "deactivate: refuses while a switch is interrupted" {
+  run_cli_ok fork default
+  echo "use default" > "$CLAUDE_PROFILE_HOME/.op-in-progress"
+
+  run_cli deactivate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"interrupted"* ]]
+}
+
 @test "restores MCP config" {
   run_cli_ok fork default
   run_cli_ok new nomcp

--- a/tests/delete.bats
+++ b/tests/delete.bats
@@ -24,6 +24,16 @@ load test_helper
   [[ "$output" == *"not found"* ]]
 }
 
+@test "rejects unexpected extra argument" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+
+  run_cli delete alpha beta
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unexpected argument"* ]]
+  [ -d "$(profile_dir alpha)" ]
+}
+
 @test "EOF at confirm prompt cancels cleanly without deleting" {
   run_cli_ok fork victim
   # fork auto-activates, so switch away so victim is deletable

--- a/tests/diff.bats
+++ b/tests/diff.bats
@@ -73,6 +73,23 @@ load test_helper
   [[ "$output" == *"no changes"* ]]
 }
 
+@test "diff: two-arg form fails on nonexistent profile name" {
+  run_cli_ok fork default
+  run_cli diff nonexistent HEAD
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "diff: user's live .gitignore does not hide unsaved changes" {
+  run_cli_ok fork default
+  echo '*.local.json' > "$CLAUDE_CODE_HOME/.gitignore"
+  echo '{"local": true}' > "$CLAUDE_CODE_HOME/settings.local.json"
+
+  run_cli diff
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"settings.local.json"* ]]
+}
+
 @test "with commit ref shows git diff" {
   run_cli_ok fork default
   run_cli_ok use default

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -22,6 +22,47 @@ EOF
   grep -q "$(profile_dir default)" "$FAKEED_OUT"
 }
 
+@test "edit: a blocking editor's change to the active profile lands in live and survives a save" {
+  run_cli_ok fork default
+
+  # A blocking editor that rewrites the profile dir's settings.json
+  local ed="$BATS_TEST_TMPDIR/ed.sh"
+  cat > "$ed" <<'EOF'
+#!/bin/bash
+echo '{"edited":"by-editor"}' > "$1/settings.json"
+EOF
+  chmod +x "$ed"
+
+  EDITOR="$ed" run_cli_ok edit default
+
+  # The edit is now the authoritative live state, not stranded in the profile dir
+  grep -q '"edited"' "$CLAUDE_CODE_HOME/settings.json"
+
+  # A later save keeps it — it is not overwritten from a stale live copy
+  run_cli_ok save -m "after edit"
+  grep -q '"edited"' "$(profile_dir default)/settings.json"
+}
+
+@test "edit: editing a non-active profile does not disturb live config" {
+  run_cli_ok fork active
+  run_cli_ok fork other
+  run_cli_ok use active
+  echo '{"live":"active-state"}' > "$CLAUDE_CODE_HOME/settings.json"
+
+  local ed="$BATS_TEST_TMPDIR/ed.sh"
+  cat > "$ed" <<'EOF'
+#!/bin/bash
+echo '{"edited":"other"}' > "$1/settings.json"
+EOF
+  chmod +x "$ed"
+
+  EDITOR="$ed" run_cli_ok edit other
+
+  # Live still belongs to the active profile — editing 'other' left it alone
+  grep -q '"active-state"' "$CLAUDE_CODE_HOME/settings.json"
+  grep -q '"edited"' "$(profile_dir other)/settings.json"
+}
+
 @test "edit: refuses while a switch is interrupted" {
   run_cli_ok fork default
   echo "use default" > "$CLAUDE_PROFILE_HOME/.op-in-progress"

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+load test_helper
+
+@test "edit: honors EDITOR including arguments" {
+  run_cli_ok fork default
+
+  # Neutralize any real `code` on PATH; the fake editor records its args
+  mkdir -p "$BATS_TEST_TMPDIR/bin"
+  printf '#!/bin/bash\nexit 0\n' > "$BATS_TEST_TMPDIR/bin/code"
+  chmod +x "$BATS_TEST_TMPDIR/bin/code"
+  cat > "$BATS_TEST_TMPDIR/bin/fakeed" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" > "$FAKEED_OUT"
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/bin/fakeed"
+  export FAKEED_OUT="$BATS_TEST_TMPDIR/fakeed.out"
+
+  PATH="$BATS_TEST_TMPDIR/bin:$PATH" EDITOR="fakeed --flag" run_cli edit default
+  [ "$status" -eq 0 ]
+  [ -f "$FAKEED_OUT" ]
+  grep -qx -- '--flag' "$FAKEED_OUT"
+  grep -q "$(profile_dir default)" "$FAKEED_OUT"
+}
+
+@test "edit: refuses while a switch is interrupted" {
+  run_cli_ok fork default
+  echo "use default" > "$CLAUDE_PROFILE_HOME/.op-in-progress"
+
+  run_cli edit default
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"interrupted"* ]]
+}

--- a/tests/fork.bats
+++ b/tests/fork.bats
@@ -7,7 +7,7 @@ load test_helper
   local dir="$(profile_dir default)"
   [ -f "$dir/settings.json" ]
   [ -d "$dir/skills/my-skill" ]
-  [ -f "$dir/.claude.json" ]
+  [ -f "$dir/.claude-profile-home.json" ]
   [ -d "$dir/.git" ]
 }
 
@@ -16,7 +16,7 @@ load test_helper
 
   local dir="$(profile_dir default)"
   grep -q '"effortLevel"' "$dir/settings.json"
-  grep -q '"mcpServers"' "$dir/.claude.json"
+  grep -q '"mcpServers"' "$dir/.claude-profile-home.json"
 }
 
 @test "creates original backup" {
@@ -25,7 +25,7 @@ load test_helper
   local backup="$(backup_dir)"
   [ -d "$backup" ]
   [ -f "$backup/settings.json" ]
-  [ -f "$backup/.claude.json" ]
+  [ -f "$backup/.claude-profile-home.json" ]
 }
 
 @test "backup happens only once" {

--- a/tests/fork.bats
+++ b/tests/fork.bats
@@ -53,3 +53,10 @@ load test_helper
   run_cli fork default
   [ "$status" -ne 0 ]
 }
+
+@test "rejects unexpected extra argument" {
+  run_cli fork first second
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unexpected argument"* ]]
+  [ ! -d "$(profile_dir first)" ]
+}

--- a/tests/git_env.bats
+++ b/tests/git_env.bats
@@ -2,6 +2,7 @@
 # Regression coverage for Git hook environments. Git launches hooks with
 # repository-local GIT_* variables exported; the test suite must scrub those at
 # load time before any fixture creates commits.
+load test_helper
 
 clean_git() (
   unset $(git rev-parse --local-env-vars 2>/dev/null) \
@@ -41,4 +42,33 @@ clean_git() (
     echo "$canary_status"
   fi
   [ -z "$canary_status" ]
+}
+
+@test "git environment: CLI scrubs inherited repository variables (hook safety)" {
+  local canary="$BATS_TEST_TMPDIR/canary"
+  clean_git init -q "$canary"
+  clean_git -C "$canary" -c user.email=test@test -c user.name=test \
+    commit -q --allow-empty -m CANARY
+  local expected_head
+  expected_head="$(clean_git -C "$canary" rev-parse HEAD)"
+
+  # Simulate being invoked from a git hook of the canary repo
+  run env \
+    GIT_DIR="$canary/.git" \
+    GIT_WORK_TREE="$canary" \
+    GIT_INDEX_FILE="$canary/.git/index" \
+    bash "$CLAUDE_PROFILE" fork hooked
+  if [[ "$status" -ne 0 ]]; then
+    echo "$output"
+  fi
+  [ "$status" -eq 0 ]
+
+  # Profile history landed in the profile repo
+  [ -d "$CLAUDE_PROFILE_HOME/hooked/.git" ]
+  [ "$(clean_git -C "$CLAUDE_PROFILE_HOME/hooked" rev-list --count HEAD)" -ge 1 ]
+
+  # Canary repo untouched
+  [ "$(clean_git -C "$canary" rev-parse HEAD)" = "$expected_head" ]
+  [ "$(clean_git -C "$canary" rev-list --count HEAD)" -eq 1 ]
+  [ -z "$(clean_git -C "$canary" status --short)" ]
 }

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -31,6 +31,12 @@ load test_helper
   [[ "$output" == *"No history"* ]]
 }
 
+@test "history: fails on nonexistent profile" {
+  run_cli history nope
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
 @test "restore: rejects path traversal in name" {
   run_cli restore "../../etc" HEAD
   [ "$status" -ne 0 ]

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -206,9 +206,11 @@ EOF
 }
 
 # ─── Remote installer ────────────────────────────────────────
+# CLAUDE_PROFILE_REPO points the installer at the local checkout so the suite
+# is hermetic (no network) and tests the code under review, not remote main.
 
 @test "remote-install: clones to temp dir, installs, cleans up" {
-  run bash "$REPO_DIR/remote-install.sh"
+  run env CLAUDE_PROFILE_REPO="file://$REPO_DIR" bash "$REPO_DIR/remote-install.sh"
   [ "$status" -eq 0 ]
   [ -f "$CLAUDE_PROFILE_INSTALL_DIR/claude-profile" ]
   [ -x "$CLAUDE_PROFILE_INSTALL_DIR/claude-profile" ]
@@ -220,12 +222,34 @@ EOF
   local tmp_before
   tmp_before="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'tmp.*' -type d 2>/dev/null | wc -l | tr -d ' ')"
 
-  bash "$REPO_DIR/remote-install.sh" >/dev/null 2>&1
+  CLAUDE_PROFILE_REPO="file://$REPO_DIR" bash "$REPO_DIR/remote-install.sh" >/dev/null 2>&1
 
   # Count tmp dirs after — should not have leftover clone dirs
   local tmp_after
   tmp_after="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'tmp.*' -type d 2>/dev/null | wc -l | tr -d ' ')"
   [ "$tmp_after" -le "$tmp_before" ]
+}
+
+@test "install: completes even when statusline setup fails" {
+  mkdir -p "$HOME/.claude"
+  echo '{"broken":' > "$HOME/.claude/settings.json"
+
+  run bash "$REPO_DIR/install.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Installation complete"* ]]
+}
+
+@test "zsh completions: expands \$ZSH in ZSH_CUSTOM from .zshrc" {
+  mkdir -p "$HOME/.oh-my-zsh"
+  echo 'ZSH_CUSTOM=$ZSH/custom' > "$HOME/.zshrc"
+
+  cd "$BATS_TEST_TMPDIR"
+  run env -u CLAUDE_PROFILE_COMPLETIONS_DIR -u ZSH -u ZSH_CUSTOM \
+    SHELL=/bin/zsh bash "$REPO_DIR/install.sh"
+  [ "$status" -eq 0 ]
+  [ -f "$HOME/.oh-my-zsh/custom/completions/_claude-profile" ]
+  # No literal "$ZSH" directory created in the cwd
+  [ ! -e "$BATS_TEST_TMPDIR/\$ZSH" ]
 }
 
 # The completion file always lands in the user completions dir. When

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -71,6 +71,27 @@ setup() {
   [[ "$output" == *"default"* ]]
 }
 
+@test "install dir containing a double-quote does not inject shell into the binary" {
+  # The installer rewrites SCRIPT_DIR in the generated binary. A path with a
+  # double-quote must not break out of the assignment and run a command when
+  # the binary is later executed.
+  local marker="$BATS_TEST_TMPDIR/PWNED"
+  export CLAUDE_PROFILE_INSTALL_DIR="$BATS_TEST_TMPDIR/li\"; touch '$marker'; x=\""
+  export CLAUDE_PROFILE_COMPLETIONS_DIR="$BATS_TEST_TMPDIR/completions2"
+
+  run bash "$REPO_DIR/install.sh"
+  [ "$status" -eq 0 ]
+
+  export CLAUDE_CODE_HOME="$HOME/.claude"
+  mkdir -p "$CLAUDE_CODE_HOME"
+  git config --global user.name "test"
+  git config --global user.email "test@test"
+  run bash "$CLAUDE_PROFILE_INSTALL_DIR/claude-profile" version
+  [ "$status" -eq 0 ]
+
+  [ ! -e "$marker" ]
+}
+
 @test "installs completions to COMPLETIONS_DIR" {
   run bash "$REPO_DIR/install.sh"
   [ "$status" -eq 0 ]
@@ -320,7 +341,23 @@ EOF
   [[ "$output" != *"Add to your PATH"* ]]
 }
 
-# ─── Sed injection safety (install path with special chars) ──
+# ─── Injection safety (install path with special chars) ──
+# The generated SCRIPT_DIR assignment must resolve to the right lib dir and run
+# no embedded command, no matter what the install path contains. Assert the
+# behaviour (the installed binary finds its libs and runs) rather than a
+# brittle string format.
+
+_installed_binary_runs() {
+  export CLAUDE_CODE_HOME="$HOME/.claude"
+  mkdir -p "$CLAUDE_CODE_HOME"
+  git config --global user.name "test"
+  git config --global user.email "test@test"
+  run bash "$CLAUDE_PROFILE_INSTALL_DIR/claude-profile" version
+  local expected
+  expected="$(sed -n '1{s/^[[:space:]]*//;s/[[:space:]]*$//;p;}' "$REPO_DIR/VERSION")"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude-profile $expected" ]
+}
 
 @test "install: handles pipe character in install path" {
   export CLAUDE_PROFILE_INSTALL_DIR="$BATS_TEST_TMPDIR/bin|pipe"
@@ -328,9 +365,7 @@ EOF
 
   run bash "$REPO_DIR/install.sh"
   [ "$status" -eq 0 ]
-
-  local expected_lib="$CLAUDE_PROFILE_INSTALL_DIR/claude-profile-lib"
-  grep -qF "SCRIPT_DIR=\"$expected_lib\"" "$CLAUDE_PROFILE_INSTALL_DIR/claude-profile"
+  _installed_binary_runs
 }
 
 @test "install: handles ampersand in install path" {
@@ -339,9 +374,7 @@ EOF
 
   run bash "$REPO_DIR/install.sh"
   [ "$status" -eq 0 ]
-
-  local expected_lib="$CLAUDE_PROFILE_INSTALL_DIR/claude-profile-lib"
-  grep -qF "SCRIPT_DIR=\"$expected_lib\"" "$CLAUDE_PROFILE_INSTALL_DIR/claude-profile"
+  _installed_binary_runs
 }
 
 @test "install: handles backslash in install path" {
@@ -350,7 +383,14 @@ EOF
 
   run bash "$REPO_DIR/install.sh"
   [ "$status" -eq 0 ]
+  _installed_binary_runs
+}
 
-  local expected_lib="$CLAUDE_PROFILE_INSTALL_DIR/claude-profile-lib"
-  grep -qF "SCRIPT_DIR=\"$expected_lib\"" "$CLAUDE_PROFILE_INSTALL_DIR/claude-profile"
+@test "install: handles a dollar sign and backtick in install path" {
+  export CLAUDE_PROFILE_INSTALL_DIR="$BATS_TEST_TMPDIR/bin\$(id)\`id\`"
+  mkdir -p "$CLAUDE_PROFILE_INSTALL_DIR"
+
+  run bash "$REPO_DIR/install.sh"
+  [ "$status" -eq 0 ]
+  _installed_binary_runs
 }

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -92,6 +92,17 @@ setup() {
   [ ! -e "$marker" ]
 }
 
+@test "install refuses a profile store nested inside the live config dir" {
+  export CLAUDE_CODE_HOME="$HOME/.claude"
+  export CLAUDE_PROFILE_HOME="$HOME/.claude/store"
+
+  run bash "$REPO_DIR/install.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must not be inside"* ]]
+  # Refused before any store was written
+  [ ! -d "$CLAUDE_PROFILE_HOME/.seed" ]
+}
+
 @test "installs completions to COMPLETIONS_DIR" {
   run bash "$REPO_DIR/install.sh"
   [ "$status" -eq 0 ]

--- a/tests/locking.bats
+++ b/tests/locking.bats
@@ -31,6 +31,18 @@ load test_helper
   [ ! -d "$CLAUDE_PROFILE_HOME/.lock" ]
 }
 
+@test "statusline install refuses to run while another holds the lock" {
+  # statusline install mutates both the store and live settings.json, so it
+  # must take the same exclusive lock as a switch or it can race one.
+  run_cli_ok fork default
+  mkdir -p "$CLAUDE_PROFILE_HOME/.lock"
+  echo "$$" > "$CLAUDE_PROFILE_HOME/.lock/pid"
+
+  run_cli statusline install
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"in progress"* ]]
+}
+
 @test "read-only commands run despite the lock" {
   run_cli_ok fork default
   mkdir -p "$CLAUDE_PROFILE_HOME/.lock"

--- a/tests/locking.bats
+++ b/tests/locking.bats
@@ -43,6 +43,54 @@ load test_helper
   [[ "$output" == *"in progress"* ]]
 }
 
+@test "lock: release only removes a lock this process owns" {
+  export PROFILES_DIR="$CLAUDE_PROFILE_HOME"
+  mkdir -p "$PROFILES_DIR"
+  source "$(dirname "$CLAUDE_PROFILE")/lib/output.sh"
+  source "$(dirname "$CLAUDE_PROFILE")/lib/state.sh"
+
+  # A lock owned by another process (token mismatch)
+  mkdir -p "$PROFILES_DIR/.lock"
+  echo 99999 > "$PROFILES_DIR/.lock/pid"
+  echo "someone-elses-token" > "$PROFILES_DIR/.lock/token"
+
+  _LOCK_TOKEN="my-token"
+  _release_lock
+
+  # Must not remove a lock we don't own — otherwise a process that lost a
+  # takeover race would delete the new owner's lock on EXIT.
+  [ -d "$PROFILES_DIR/.lock" ]
+  [ "$(cat "$PROFILES_DIR/.lock/token")" = "someone-elses-token" ]
+}
+
+@test "lock: release removes a lock whose token matches this process" {
+  export PROFILES_DIR="$CLAUDE_PROFILE_HOME"
+  mkdir -p "$PROFILES_DIR"
+  source "$(dirname "$CLAUDE_PROFILE")/lib/output.sh"
+  source "$(dirname "$CLAUDE_PROFILE")/lib/state.sh"
+
+  mkdir -p "$PROFILES_DIR/.lock"
+  echo $$ > "$PROFILES_DIR/.lock/pid"
+  echo "my-token" > "$PROFILES_DIR/.lock/token"
+
+  _LOCK_TOKEN="my-token"
+  _release_lock
+
+  [ ! -d "$PROFILES_DIR/.lock" ]
+}
+
+@test "lock: a refused command does not disturb the live lock it failed to take" {
+  run_cli_ok fork default
+  mkdir -p "$CLAUDE_PROFILE_HOME/.lock"
+  echo "$$" > "$CLAUDE_PROFILE_HOME/.lock/pid"
+  echo "held-by-live-process" > "$CLAUDE_PROFILE_HOME/.lock/token"
+
+  run_cli save -m x
+  [ "$status" -ne 0 ]
+  [ -d "$CLAUDE_PROFILE_HOME/.lock" ]
+  [ "$(cat "$CLAUDE_PROFILE_HOME/.lock/token")" = "held-by-live-process" ]
+}
+
 @test "read-only commands run despite the lock" {
   run_cli_ok fork default
   mkdir -p "$CLAUDE_PROFILE_HOME/.lock"

--- a/tests/locking.bats
+++ b/tests/locking.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+load test_helper
+
+@test "mutating command refuses to run while another holds the lock" {
+  run_cli_ok fork default
+  mkdir -p "$CLAUDE_PROFILE_HOME/.lock"
+  echo "$$" > "$CLAUDE_PROFILE_HOME/.lock/pid"
+
+  run_cli save -m x
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"in progress"* ]]
+}
+
+@test "stale lock from a dead process is taken over" {
+  run_cli_ok fork default
+  local dead_pid
+  dead_pid="$(bash -c 'echo $$')"
+  mkdir -p "$CLAUDE_PROFILE_HOME/.lock"
+  echo "$dead_pid" > "$CLAUDE_PROFILE_HOME/.lock/pid"
+
+  echo '{"after_stale": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli save -m "stale lock"
+  [ "$status" -eq 0 ]
+  [ ! -d "$CLAUDE_PROFILE_HOME/.lock" ]
+}
+
+@test "lock is released after a mutating command finishes" {
+  run_cli_ok fork default
+  [ ! -d "$CLAUDE_PROFILE_HOME/.lock" ]
+  run_cli_ok save -m x
+  [ ! -d "$CLAUDE_PROFILE_HOME/.lock" ]
+}
+
+@test "read-only commands run despite the lock" {
+  run_cli_ok fork default
+  mkdir -p "$CLAUDE_PROFILE_HOME/.lock"
+  echo "$$" > "$CLAUDE_PROFILE_HOME/.lock/pid"
+
+  run_cli list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"default"* ]]
+}

--- a/tests/new.bats
+++ b/tests/new.bats
@@ -26,6 +26,14 @@ load test_helper
   [[ "$output" == *"Usage"* ]]
 }
 
+@test "rejects unexpected extra argument" {
+  run_cli new first second
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unexpected argument"* ]]
+  [ ! -d "$(profile_dir first)" ]
+  [ ! -d "$(profile_dir second)" ]
+}
+
 @test "uses custom .seed/ directory when present" {
   mkdir -p "$CLAUDE_PROFILE_HOME/.seed"
   echo '{"custom": true}' > "$CLAUDE_PROFILE_HOME/.seed/settings.json"

--- a/tests/new.bats
+++ b/tests/new.bats
@@ -43,7 +43,7 @@ load test_helper
 
   local dir="$(profile_dir seeded)"
   grep -q '"custom"' "$dir/settings.json"
-  grep -q '"default"' "$dir/.claude.json"
+  grep -q '"default"' "$dir/.claude-profile-home.json"
 }
 
 @test "custom .seed/ overrides built-in defaults" {
@@ -56,4 +56,5 @@ load test_helper
   local dir="$(profile_dir custom)"
   [[ "$(cat "$dir/settings.json")" == '{"only": "this"}' ]]
   [ ! -f "$dir/.claude.json" ]
+  [ ! -f "$dir/.claude-profile-home.json" ]
 }

--- a/tests/path_resolution.bats
+++ b/tests/path_resolution.bats
@@ -26,3 +26,17 @@ load test_helper
   [ -d "$custom/priority-test" ]
   [ ! -d "$xdg/claude-profile/priority-test" ]
 }
+
+@test "path: refuses profile store nested inside ~/.claude" {
+  export CLAUDE_PROFILE_HOME="$CLAUDE_CODE_HOME/__profiles__"
+  run_cli list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must not be inside"* ]]
+}
+
+@test "path: refuses ~/.claude nested inside the profile store" {
+  export CLAUDE_CODE_HOME="$CLAUDE_PROFILE_HOME/live"
+  run_cli list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must not be inside"* ]]
+}

--- a/tests/path_resolution.bats
+++ b/tests/path_resolution.bats
@@ -40,3 +40,43 @@ load test_helper
   [ "$status" -ne 0 ]
   [[ "$output" == *"must not be inside"* ]]
 }
+
+@test "path: refuses a store nested in the live dir spelled with a relative path" {
+  mkdir -p "$CLAUDE_CODE_HOME/sub"
+  cd "$CLAUDE_CODE_HOME/sub"
+  export CLAUDE_PROFILE_HOME="../store"   # canonically inside the live dir
+  run_cli list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must not be inside"* ]]
+}
+
+@test "path: refuses a store nested in the live dir via a symlink alias" {
+  ln -s "$CLAUDE_CODE_HOME" "$HOME/alias"
+  export CLAUDE_PROFILE_HOME="$HOME/alias/store"   # alias resolves into the live dir
+  run_cli list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must not be inside"* ]]
+}
+
+@test "path: accepts a legitimately symlinked store root" {
+  # A symlinked store ROOT that points somewhere outside the live dir is fine —
+  # only symlinked individual profile dirs are refused (see save test below).
+  local real="$BATS_TEST_TMPDIR/real-store"
+  mkdir -p "$real"
+  ln -s "$real" "$HOME/store-link"
+  export CLAUDE_PROFILE_HOME="$HOME/store-link"
+  run_cli_ok fork default
+  [ -d "$real/default" ]
+}
+
+@test "path: save refuses a symlinked profile root and never touches its target" {
+  run_cli_ok fork real
+  local ext="$BATS_TEST_TMPDIR/external"
+  mkdir -p "$ext"
+  echo 'CANARY' > "$ext/canary.txt"
+  ln -s "$ext" "$CLAUDE_PROFILE_HOME/evil"
+
+  run_cli save evil
+  [ "$status" -ne 0 ]
+  [ -f "$ext/canary.txt" ]      # external file survives — no rm -rf through the symlink
+}

--- a/tests/permissions.bats
+++ b/tests/permissions.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+load test_helper
+
+# Portable "octal mode of a path" — macOS stat differs from GNU stat.
+_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+@test "permissions: profile store root is not accessible to group/other" {
+  run_cli_ok fork default
+  local mode
+  mode="$(_mode "$CLAUDE_PROFILE_HOME")"
+  [ "$mode" = "700" ]
+}
+
+@test "permissions: newly created profile dir is private" {
+  run_cli_ok fork default
+  local mode
+  mode="$(_mode "$(profile_dir default)")"
+  # No group/other bits — private to the owner
+  [[ "$mode" == 7?? ]]
+  [[ "$mode" == ?00 ]]
+}
+
+@test "permissions: git objects are unreachable behind a 700 store root" {
+  run_cli_ok fork default
+  echo '{"changed": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok save -m "change"
+  # Even if inner objects are group/world-readable, a 700 root blocks traversal.
+  local mode
+  mode="$(_mode "$CLAUDE_PROFILE_HOME")"
+  [ "$mode" = "700" ]
+}
+
+@test "permissions: an existing group-readable store is tightened on next run" {
+  run_cli_ok fork default
+  chmod 755 "$CLAUDE_PROFILE_HOME"
+  run_cli_ok list
+  local mode
+  mode="$(_mode "$CLAUDE_PROFILE_HOME")"
+  [ "$mode" = "700" ]
+}

--- a/tests/restore.bats
+++ b/tests/restore.bats
@@ -114,3 +114,53 @@ load test_helper
   [ "$status" -ne 0 ]
   [[ "$output" == *"Usage"* ]]
 }
+
+@test "restore: aborts when the auto-save cannot be committed" {
+  run_cli_ok fork default
+  local dir="$(profile_dir default)"
+  local initial
+  initial="$(git -C "$dir" log --format='%H' -1)"
+  echo '{"v2": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok save -m "Version 2"
+  echo '{"unsaved": true}' > "$CLAUDE_CODE_HOME/settings.json"
+
+  # Make every commit in this repo fail
+  git -C "$dir" config commit.gpgsign true
+  git -C "$dir" config gpg.program /nonexistent-gpg
+
+  run_cli restore "$initial"
+  [ "$status" -ne 0 ]
+  # unsaved live change still present
+  grep -q '"unsaved"' "$CLAUDE_CODE_HOME/settings.json"
+}
+
+@test "restore: two-arg form fails on nonexistent profile name" {
+  run_cli_ok fork default
+  echo '{"v2": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok save -m v2
+
+  run_cli restore nonexistent HEAD
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+  grep -q '"v2"' "$CLAUDE_CODE_HOME/settings.json"
+}
+
+@test "restore: failed checkout does not leave the profile tree empty" {
+  run_cli_ok fork default
+  local dir="$(profile_dir default)"
+  local initial
+  initial="$(git -C "$dir" log --format='%H' -1)"
+
+  echo '{"v2": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok save -m "Version 2"
+
+  # Remove the initial commit's root tree object so its checkout must fail
+  local tree
+  tree="$(git -C "$dir" rev-parse "$initial^{tree}")"
+  rm -f "$dir/.git/objects/${tree:0:2}/${tree:2}"
+
+  run_cli restore default "$initial"
+  [ "$status" -ne 0 ]
+  [ -f "$dir/settings.json" ]
+  grep -q '"v2"' "$dir/settings.json"
+}

--- a/tests/restore.bats
+++ b/tests/restore.bats
@@ -164,3 +164,22 @@ load test_helper
   [ -f "$dir/settings.json" ]
   grep -q '"v2"' "$dir/settings.json"
 }
+
+@test "restore: refuses a symlinked profile root and never touches its target" {
+  run_cli_ok fork real
+
+  # An external git repo standing in for a symlinked profile's target
+  local ext="$BATS_TEST_TMPDIR/external"
+  mkdir -p "$ext"
+  echo 'CANARY' > "$ext/canary.txt"
+  git -C "$ext" init -q
+  git -C "$ext" add -A
+  git -C "$ext" commit -q -m "external"
+
+  ln -s "$ext" "$CLAUDE_PROFILE_HOME/evil"
+
+  run_cli restore evil HEAD
+  [ "$status" -ne 0 ]
+  # git rm -rf . must not have run against the symlink's target
+  [ -f "$ext/canary.txt" ]
+}

--- a/tests/save.bats
+++ b/tests/save.bats
@@ -45,7 +45,7 @@ load test_helper
 
   run_cli_ok save -m "removed"
   [ ! -d "$(profile_dir default)/skills" ]
-  [ ! -f "$(profile_dir default)/.claude.json" ]
+  [ ! -f "$(profile_dir default)/.claude-profile-home.json" ]
 }
 
 @test "save: profile keeps its previous copy when copying an entry fails" {

--- a/tests/save.bats
+++ b/tests/save.bats
@@ -38,6 +38,67 @@ load test_helper
   ! grep -q '"modified"' "$CLAUDE_CODE_HOME/settings.json"
 }
 
+@test "save: propagates top-level deletions to the profile" {
+  run_cli_ok fork default
+  rm -rf "$CLAUDE_CODE_HOME/skills"
+  rm -f "$HOME/.claude.json"
+
+  run_cli_ok save -m "removed"
+  [ ! -d "$(profile_dir default)/skills" ]
+  [ ! -f "$(profile_dir default)/.claude.json" ]
+}
+
+@test "save: profile keeps its previous copy when copying an entry fails" {
+  run_cli_ok fork default
+  chmod 000 "$CLAUDE_CODE_HOME/skills/my-skill/SKILL.md"
+
+  run_cli save -m "will fail"
+  local st="$status"
+  chmod 644 "$CLAUDE_CODE_HOME/skills/my-skill/SKILL.md"
+
+  [ "$st" -ne 0 ]
+  [ -f "$(profile_dir default)/skills/my-skill/SKILL.md" ]
+}
+
+@test "save: refuses while a switch is interrupted" {
+  run_cli_ok fork default
+  echo "use default" > "$CLAUDE_PROFILE_HOME/.op-in-progress"
+
+  run_cli save -m x
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"interrupted"* ]]
+}
+
+@test "save: rejects unexpected extra argument" {
+  run_cli_ok fork default
+  run_cli save default extra -m "msg"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unexpected argument"* ]]
+  [ ! -d "$(profile_dir extra)" ]
+}
+
+@test "save: -m without a message fails cleanly" {
+  run_cli_ok fork default
+  run_cli save -m
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"✗"* ]]
+  [[ "$output" == *"-m requires a message"* ]]
+}
+
+@test "save: warns but succeeds when git history cannot be recorded" {
+  run_cli_ok fork default
+  echo '{"changed": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  chmod -R a-w "$(profile_dir default)/.git"
+
+  run_cli save -m "history blocked"
+  local st="$status" out="$output"
+  chmod -R u+w "$(profile_dir default)/.git"
+
+  [ "$st" -eq 0 ]
+  [[ "$out" == *"history"* ]]
+  grep -q '"changed"' "$(profile_dir default)/settings.json"
+}
+
 @test "no-op when nothing changed" {
   run_cli_ok fork default
   run_cli_ok use default

--- a/tests/save.bats
+++ b/tests/save.bats
@@ -60,6 +60,35 @@ load test_helper
   [ -f "$(profile_dir default)/skills/my-skill/SKILL.md" ]
 }
 
+@test "save: a live file named .saving.* is captured, not skipped as staging" {
+  echo 'SECRET' > "$CLAUDE_CODE_HOME/.saving.credentials"
+  run_cli_ok fork default
+  echo '{"changed": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok save -m "with saving file"
+
+  [ -f "$(profile_dir default)/.saving.credentials" ]
+  [ "$(cat "$(profile_dir default)/.saving.credentials")" = "SECRET" ]
+}
+
+@test "use: a .saving.* user file survives a switch round-trip" {
+  echo 'SECRET' > "$CLAUDE_CODE_HOME/.saving.data"
+  run_cli_ok fork p1
+  run_cli_ok new p2
+  run_cli_ok use p1
+
+  [ -f "$CLAUDE_CODE_HOME/.saving.data" ]
+  [ "$(cat "$CLAUDE_CODE_HOME/.saving.data")" = "SECRET" ]
+}
+
+@test "save: staging lives outside the profile payload" {
+  run_cli_ok fork default
+  echo '{"changed": true}' > "$CLAUDE_CODE_HOME/settings.json"
+  run_cli_ok save -m "copy save"
+  # No staging artifacts left inside the profile directory
+  run bash -c "ls -a '$(profile_dir default)' | grep -c '^\.saving'"
+  [ "$output" -eq 0 ]
+}
+
 @test "save: refuses while a switch is interrupted" {
   run_cli_ok fork default
   echo "use default" > "$CLAUDE_PROFILE_HOME/.op-in-progress"

--- a/tests/security.bats
+++ b/tests/security.bats
@@ -206,6 +206,8 @@ load test_helper
   run_cli use brokenlink
   [ "$status" -ne 0 ]
   [[ "$output" == *"Broken symlink"* ]]
+  # The offending path is named so the user can fix it
+  [[ "$output" == *"bad"* ]]
 }
 
 @test "use: rejects unreadable regular files in profile" {

--- a/tests/statusline.bats
+++ b/tests/statusline.bats
@@ -64,6 +64,22 @@ load test_helper
   [[ "$output" != *"no jq"* ]]
 }
 
+@test "statusline install: unwritable settings dir fails honestly, preserves the file" {
+  command -v jq &>/dev/null || skip "test targets the jq code path"
+  local before
+  before="$(cat "$CLAUDE_CODE_HOME/settings.json")"
+
+  chmod 555 "$CLAUDE_CODE_HOME"
+  run_cli statusline install
+  chmod 755 "$CLAUDE_CODE_HOME"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"configured"* ]]
+  # The original file is untouched — never truncated — and still valid JSON
+  [ "$(cat "$CLAUDE_CODE_HOME/settings.json")" = "$before" ]
+  jq -e . "$CLAUDE_CODE_HOME/settings.json" >/dev/null
+}
+
 @test "statusline install respects custom CLAUDE_PROFILE_HOME in script path" {
   export CLAUDE_PROFILE_HOME="$HOME/custom-profiles"
   mkdir -p "$CLAUDE_PROFILE_HOME"

--- a/tests/statusline.bats
+++ b/tests/statusline.bats
@@ -35,6 +35,35 @@ load test_helper
   [[ "$output" == *"already configured"* ]]
 }
 
+@test "statusline: bare invocation shows usage instead of installing" {
+  run_cli statusline
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+  [ ! -f "$CLAUDE_PROFILE_HOME/statusline.sh" ]
+}
+
+@test "statusline install: preserves a symlinked settings.json" {
+  command -v jq &>/dev/null || skip "test targets the jq code path"
+  local real="$BATS_TEST_TMPDIR/dotfiles-settings.json"
+  mv "$CLAUDE_CODE_HOME/settings.json" "$real"
+  ln -s "$real" "$CLAUDE_CODE_HOME/settings.json"
+
+  run_cli_ok statusline install
+  [ -L "$CLAUDE_CODE_HOME/settings.json" ]
+  grep -q '"statusLine"' "$real"
+}
+
+@test "statusline install: invalid settings.json reported as such" {
+  command -v jq &>/dev/null || command -v python3 &>/dev/null || command -v node &>/dev/null \
+    || skip "no JSON tool available"
+  echo '{"broken":' > "$CLAUDE_CODE_HOME/settings.json"
+
+  run_cli statusline install
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not valid JSON"* ]]
+  [[ "$output" != *"no jq"* ]]
+}
+
 @test "statusline install respects custom CLAUDE_PROFILE_HOME in script path" {
   export CLAUDE_PROFILE_HOME="$HOME/custom-profiles"
   mkdir -p "$CLAUDE_PROFILE_HOME"

--- a/tests/use.bats
+++ b/tests/use.bats
@@ -62,8 +62,8 @@ load test_helper
   run_cli_ok use with-mcp
   [ -f "$HOME/.claude.json" ]
 
-  # Remove .claude.json from no-mcp AFTER auto-save has run
-  rm -f "$(profile_dir no-mcp)/.claude.json"
+  # Remove the stored home file from no-mcp AFTER auto-save has run
+  rm -f "$(profile_dir no-mcp)/.claude-profile-home.json"
 
   run_cli_ok use no-mcp
   # .claude.json should be gone since no-mcp profile doesn't have it
@@ -195,7 +195,7 @@ load test_helper
   run_cli use dst
   [ "$status" -eq 0 ]
   # dst's stored MCP config was never overwritten by src's
-  grep -q '"mcp":"DST"' "$(profile_dir dst)/.claude.json"
+  grep -q '"mcp":"DST"' "$(profile_dir dst)/.claude-profile-home.json"
   grep -q '"mcp":"DST"' "$HOME/.claude.json"
 }
 

--- a/tests/use.bats
+++ b/tests/use.bats
@@ -82,6 +82,76 @@ load test_helper
   grep -q '"mcpServers"' "$HOME/.claude.json"
 }
 
+@test "use: reloads active profile when live config was lost" {
+  run_cli_ok fork default
+
+  # Simulate an interrupted switch: live state gone, .current still set
+  rm -rf "$CLAUDE_CODE_HOME"
+  mkdir -p "$CLAUDE_CODE_HOME"
+  rm -f "$HOME/.claude.json"
+
+  run_cli use default
+  [ "$status" -eq 0 ]
+  [ -f "$CLAUDE_CODE_HOME/settings.json" ]
+  grep -q '"effortLevel"' "$CLAUDE_CODE_HOME/settings.json"
+  [ -f "$HOME/.claude.json" ]
+}
+
+@test "use: recovers an interrupted switch without corrupting the previous profile" {
+  # Two profiles with distinct content, work active
+  echo '{"who": "home"}' > "$CLAUDE_CODE_HOME/settings.json"
+  mkdir -p "$CLAUDE_CODE_HOME/todos"
+  echo "home todo" > "$CLAUDE_CODE_HOME/todos/t.md"
+  run_cli_ok fork home
+  run_cli_ok new work
+  echo '{"who": "work"}' > "$CLAUDE_CODE_HOME/settings.json"
+  mkdir -p "$CLAUDE_CODE_HOME/todos"
+  echo "work todo" > "$CLAUDE_CODE_HOME/todos/t.md"
+
+  # Simulate `use home` dying mid-load: auto-save of work completed...
+  mv "$CLAUDE_CODE_HOME/settings.json" "$(profile_dir work)/settings.json"
+  rm -rf "$(profile_dir work)/todos"
+  mv "$CLAUDE_CODE_HOME/todos" "$(profile_dir work)/todos"
+  cp "$HOME/.claude.json" "$(profile_dir work)/.claude.json"
+  # ...then home's load moved only settings.json before the crash
+  rm -f "$HOME/.claude.json"
+  mv "$(profile_dir home)/settings.json" "$CLAUDE_CODE_HOME/settings.json"
+  echo "use home" > "$CLAUDE_PROFILE_HOME/.op-in-progress"
+
+  run_cli use home
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"interrupted"* ]]
+
+  # home fully live
+  grep -q '"who": "home"' "$CLAUDE_CODE_HOME/settings.json"
+  grep -q "home todo" "$CLAUDE_CODE_HOME/todos/t.md"
+  [ -f "$HOME/.claude.json" ]
+  # work profile intact — not polluted by home's partial files
+  grep -q '"who": "work"' "$(profile_dir work)/settings.json"
+  grep -q "work todo" "$(profile_dir work)/todos/t.md"
+}
+
+@test "use: deleted ~/.claude.json does not resurrect after a switch round-trip" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+  run_cli_ok use alpha
+
+  rm -f "$HOME/.claude.json"
+  run_cli_ok use beta
+  run_cli_ok use alpha
+
+  [ ! -f "$HOME/.claude.json" ]
+}
+
+@test "use: rejects unexpected extra argument" {
+  run_cli_ok fork alpha
+  run_cli_ok fork beta
+
+  run_cli use alpha beta
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unexpected argument"* ]]
+}
+
 @test "use: summary shows live contents after target profile is moved thin" {
   run_cli_ok fork alpha
   run_cli_ok fork beta

--- a/tests/use.bats
+++ b/tests/use.bats
@@ -152,6 +152,53 @@ load test_helper
   [[ "$output" == *"Unexpected argument"* ]]
 }
 
+@test "use: recovers a switch interrupted during the outgoing save without deleting the source's data" {
+  echo '{"who":"A"}' > "$CLAUDE_CODE_HOME/settings.json"
+  mkdir -p "$CLAUDE_CODE_HOME/agents"
+  echo 'AGENT-A' > "$CLAUDE_CODE_HOME/agents/a.md"
+  run_cli_ok fork A
+  run_cli_ok new B
+  run_cli_ok use A
+
+  # Simulate `use B` dying mid outgoing-save of A: settings.json already moved
+  # into A's profile dir and gone from live, agents/ not yet moved. The
+  # saving-phase marker is written BEFORE the first destructive move.
+  mv "$CLAUDE_CODE_HOME/settings.json" "$(profile_dir A)/settings.json"
+  printf 'op=use\nphase=saving\nsource=A\ntarget=B\n' > "$CLAUDE_PROFILE_HOME/.op-in-progress"
+
+  run_cli use B
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"interrupted"* ]]
+
+  # A's sole copy of settings.json survived — not deleted by an exact-sync save
+  grep -q '"who":"A"' "$(profile_dir A)/settings.json"
+  grep -q 'AGENT-A' "$(profile_dir A)/agents/a.md"
+  # The switch to B completed
+  [ "$(cat "$CLAUDE_PROFILE_HOME/.current")" = "B" ]
+}
+
+@test "use: recovery at the save/load boundary keeps the target profile's .claude.json intact" {
+  echo '{"mcp":"SRC"}' > "$HOME/.claude.json"
+  run_cli_ok fork src
+  run_cli_ok new dst
+  echo '{"mcp":"DST"}' > "$HOME/.claude.json"
+  run_cli_ok save dst
+  run_cli_ok use src        # dst locked with DST config, src active with SRC
+
+  # Simulate `use dst` interrupted at the save->load boundary. The fix leaves
+  # live fully empty at that point (the outgoing --move clears ~/.claude.json
+  # too), so recovery has nothing of src's to leak into dst.
+  find "$CLAUDE_CODE_HOME" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+  rm -f "$HOME/.claude.json"
+  printf 'op=use\nphase=loading\nsource=src\ntarget=dst\n' > "$CLAUDE_PROFILE_HOME/.op-in-progress"
+
+  run_cli use dst
+  [ "$status" -eq 0 ]
+  # dst's stored MCP config was never overwritten by src's
+  grep -q '"mcp":"DST"' "$(profile_dir dst)/.claude.json"
+  grep -q '"mcp":"DST"' "$HOME/.claude.json"
+}
+
 @test "use: summary shows live contents after target profile is moved thin" {
   run_cli_ok fork alpha
   run_cli_ok fork beta

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,9 +12,12 @@ ZDOTDIR_PATH="${ZDOTDIR:-$HOME}"
 
 expand_home_path() {
   local path="$1"
+  local zsh_dir="${ZSH:-$HOME/.oh-my-zsh}"
   path="${path/#\~/$HOME}"
   path="${path//\$\{HOME\}/$HOME}"
   path="${path//\$HOME/$HOME}"
+  path="${path//\$\{ZSH\}/$zsh_dir}"
+  path="${path//\$ZSH/$zsh_dir}"
   printf '%s\n' "$path"
 }
 
@@ -23,19 +26,30 @@ detect_oh_my_zsh_custom_dir() {
   local custom_dir=""
 
   if [[ -n "${ZSH_CUSTOM:-}" ]]; then
-    expand_home_path "$ZSH_CUSTOM"
-    return 0
+    custom_dir="$(expand_home_path "$ZSH_CUSTOM")"
+    if [[ "$custom_dir" == /* ]]; then
+      printf '%s\n' "$custom_dir"
+      return 0
+    fi
+    custom_dir=""
   fi
 
   if [[ -f "$rc" ]]; then
     custom_dir="$(sed -nE 's/^[[:space:]]*(export[[:space:]]+)?ZSH_CUSTOM=//p' "$rc" | tail -n 1)"
+    custom_dir="${custom_dir%%#*}"
+    custom_dir="$(printf '%s' "$custom_dir" | sed -E 's/[[:space:]]+$//')"
     custom_dir="${custom_dir%\"}"
     custom_dir="${custom_dir#\"}"
     custom_dir="${custom_dir%\'}"
     custom_dir="${custom_dir#\'}"
     if [[ -n "$custom_dir" ]]; then
-      expand_home_path "$custom_dir"
-      return 0
+      custom_dir="$(expand_home_path "$custom_dir")"
+      # Only trust an absolute result — a relative path would make the
+      # uninstaller look for completions in whatever cwd it runs from
+      if [[ "$custom_dir" == /* ]]; then
+        printf '%s\n' "$custom_dir"
+        return 0
+      fi
     fi
   fi
 


### PR DESCRIPTION
A hardening pass over `claude-profile` covering data-safety, crash recovery, and hostile-input handling, with a regression test written first for each change.

## Data safety & crash recovery

- **Git env isolation** — repository-local git env vars (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`) are scrubbed at startup, so profile git operations always target the profile repo even when the CLI runs from a git hook.
- **Interrupted-switch recovery** — the destructive phase of `use`/`new`/`restore`/`deactivate` is bracketed by an `.op-in-progress` marker. `use` recovers by sweeping partially moved files back to their source profile; `deactivate` completes its own interrupted restore; other mutating commands refuse until recovery. `use` reloads the active profile when the live config is empty instead of reporting "already active".
- **Exclusive lock** — mutating commands take a stale-safe `mkdir` lock so concurrent invocations can't interleave `rm`/`mv` on the same live files.
- **Atomic original backup** — the backup builds in a temp dir and moves into place; a snapshot that fails partway never leaves a directory later treated as complete. Live states with broken symlinks are refused rather than silently dropped.
- **Exact-snapshot saves** — entries and `~/.claude.json` deleted from the live state are removed from the profile copy (deletions no longer resurrect on the next switch). Copy-mode saves stage each entry to a temp name so the profile keeps its previous copy on failure. An empty live state is never saved.
- **Restore safety** — the backup is validated (including files nested in readable dirs) before `deactivate` empties the live config; the restore auto-save is verified to have committed cleanly before rollback; HEAD is re-checked-out if a restore checkout fails.

## Correctness & UX

- git `add`/`commit` failures are reported instead of silently succeeding.
- `restore`/`diff` two-arg forms parse as positional `<name> <ref>` and require the profile to exist; `history` requires an existing profile; unexpected extra arguments are rejected across `new`/`use`/`save`/`fork`/`delete`.
- A profile store nested inside the live config dir (or the reverse) is refused; `.current` is validated before `current` prints it; the user's live `.git`/`.gitignore` is kept out of the diff snapshot; `EDITOR` runs through a shell so multi-word values work; bare `statusline` shows usage; a symlinked `settings.json` is written through; invalid JSON is reported distinctly from missing tools.

## Install/release

- `$ZSH` in `ZSH_CUSTOM` is expanded and an absolute completions path is required (install/uninstall); `install.sh` continues if statusline setup fails; `remote-install.sh` is wrapped in a `main` function and honors `CLAUDE_PROFILE_REPO` for hermetic testing.
