### PR TITLE
Fix format-2 recovery documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <br>
 
 [![CI](https://img.shields.io/github/actions/workflow/status/yarikleto/claude-profile/tests.yml?branch=main&label=CI&logo=github&logoColor=white)](https://github.com/yarikleto/claude-profile/actions/workflows/tests.yml)
-[![Test count](https://img.shields.io/badge/tests-289%20passing-brightgreen?logo=github&logoColor=white)](tests/)
+[![Test count](https://img.shields.io/badge/tests-290%20passing-brightgreen?logo=github&logoColor=white)](tests/)
 [![CLI version](https://img.shields.io/github/v/tag/yarikleto/claude-profile?label=CLI&sort=semver&filter=v*&color=18182f)](https://github.com/yarikleto/claude-profile/tags)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey?logo=apple&logoColor=white)](#install)
 [![Shell: Bash](https://img.shields.io/badge/shell-Bash-4EAA25?logo=gnubash&logoColor=white)](claude-profile)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,11 +68,12 @@ Profiles are stored in an XDG-compliant location, separate from `~/.claude/`:
 ├── .current                                # one line: name of active profile
 ├── .seed/                                  # templates for `new` (user-editable)
 │   ├── settings.json
-│   └── .claude.json
+│   └── .claude.json                        # template for ~/.claude.json
 ├── .pre-profiles-backup/                   # original state backup
 │   ├── settings.json
 │   ├── CLAUDE.md
 │   ├── projects/
+│   ├── .claude-profile-home.json           # stored copy of ~/.claude.json
 │   └── ...
 ├── statusline.sh                           # statusline script for Claude Code
 ├── default/                                # a profile
@@ -84,7 +85,7 @@ Profiles are stored in an XDG-compliant location, separate from `~/.claude/`:
 │   ├── projects/
 │   ├── plugins/
 │   ├── history.jsonl
-│   ├── .claude.json                        #   stored copy of ~/.claude.json
+│   ├── .claude-profile-home.json           #   stored copy of ~/.claude.json
 │   └── ...
 └── code-review/                            # another profile
     └── ...
@@ -94,7 +95,14 @@ Profiles are stored in an XDG-compliant location, separate from `~/.claude/`:
 
 Priority: `CLAUDE_PROFILE_HOME` > `XDG_DATA_HOME/claude-profile` > `$HOME/.local/share/claude-profile`
 
-The `~/.claude.json` file (MCP server config) lives in `$HOME`, not inside `~/.claude/`. It is stored as `.claude.json` inside each profile directory and copied to/from `$HOME/.claude.json` on switch.
+The home-level `~/.claude.json` file (including MCP server config) lives in
+`$HOME`, not inside `~/.claude/`. It is stored as
+`.claude-profile-home.json` inside each profile directory and copied to/from
+`$HOME/.claude.json` on switch. This reserved name is disjoint from a live
+payload file literally named `~/.claude/.claude.json`, which is stored at the
+profile root as `.claude.json`. Before format 2, the home-level file used that
+root `.claude.json` path; startup migration moves legacy stores to the reserved
+name.
 
 ## Full-directory snapshots
 
@@ -116,7 +124,7 @@ Creates a new profile from the current live state.
 1. _ensure_original_backup()     ← one-time backup + seed creation
 2. Auto-save current profile     ← if one is active (cp)
 3. mkdir profile dir
-4. _snapshot_current()           ← cp entire ~/.claude/ + ~/.claude.json to profile
+4. _snapshot_current()           ← cp ~/.claude/ + ~/.claude.json as .claude-profile-home.json
 5. _git_init()                   ← init git with static .gitignore
 6. set_current()
 ```
@@ -145,12 +153,12 @@ The core operation. Uses `--move` for speed.
 2. _validate_profile_for_load(target)   ← pre-check before destructive ops
 3. _save_current_to(current, --move)
    ├── mv all items: ~/.claude/ → current profile dir
-   ├── cp ~/.claude.json → current profile dir
+   ├── cp ~/.claude.json → current/.claude-profile-home.json
    └── git commit
 4. _load_profile_to_live(new, --move)
    ├── clear ~/.claude/
    ├── mv items: new profile dir → ~/.claude/
-   ├── cp .claude.json → ~/.claude.json
+   ├── cp new/.claude-profile-home.json → ~/.claude.json
 5. set_current(new)
 ```
 
@@ -161,7 +169,7 @@ Explicit save. Uses `cp` (user continues working).
 ```
 1. _save_current_to(current)
    ├── cp all items: ~/.claude/ → profile dir
-   ├── cp ~/.claude.json → profile dir
+   ├── cp ~/.claude.json → current/.claude-profile-home.json
    └── git commit
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Think of it like git branches. Your original `~/.claude/` state is the **main br
 │   ├── .git/
 │   ├── settings.json
 │   ├── projects/
-│   ├── .claude.json                        # stored copy of ~/.claude.json
+│   ├── .claude-profile-home.json           # stored copy of ~/.claude.json
 │   └── ...
 └── code-review/
     ├── .git/
@@ -32,9 +32,14 @@ Think of it like git branches. Your original `~/.claude/` state is the **main br
 
 Profiles are stored in `~/.local/share/claude-profile/` (XDG-compliant), separate from `~/.claude/`. Each profile snapshots the **entire** `~/.claude/` directory plus `~/.claude.json`.
 
+Inside a stored profile, the home-level `~/.claude.json` is named
+`.claude-profile-home.json`. The reserved name keeps it separate from a payload
+file literally named `~/.claude/.claude.json`, which remains `.claude.json` at
+the profile root.
+
 ## Seed templates
 
-When you run `claude-profile new`, the new profile is seeded with files from `~/.local/share/claude-profile/.seed/`. This directory is created automatically during installation with minimal defaults (empty `settings.json` and `.claude.json`).
+When you run `claude-profile new`, the new profile is seeded with files from `~/.local/share/claude-profile/.seed/`. This directory is created automatically during installation with minimal defaults (empty `settings.json` and `.claude.json`). The seed keeps the familiar `.claude.json` template name; `new` stores that template as `.claude-profile-home.json` inside the profile.
 
 You can customize these templates:
 
@@ -52,7 +57,7 @@ Next time you run `new`, it will use your custom templates.
 
 Each profile has its own git history for tracking configuration changes. A static `.gitignore` excludes large data directories from git while still copying them between profiles:
 
-- **Git-tracked**: `settings.json`, `CLAUDE.md`, `agents/`, `skills/`, `rules/`, `keybindings.json`, `.claude.json`, etc.
+- **Git-tracked**: `settings.json`, `CLAUDE.md`, `agents/`, `skills/`, `rules/`, `keybindings.json`, `.claude-profile-home.json`, etc.
 - **Git-ignored** (still copied): `projects/`, `agent-memory/`, `todos/`, `plans/`, `tasks/`, `plugins/`, `history.jsonl`
 
 This means `history`, `diff`, and `restore` commands only operate on config files, while all data is still fully isolated between profiles.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -101,15 +101,24 @@ mv ~/.claude/__profiles__ ~/.local/share/claude-profile
 
 **I ran `deactivate` (without --keep) and lost my config:**
 
-Your profile is still saved. Find it and copy the files back:
+Your profile is still saved. Find it and copy the files back. In the current
+store format, the home-level `~/.claude.json` uses a reserved filename inside
+the profile so it cannot collide with a payload file named
+`~/.claude/.claude.json`:
 
 ```bash
 ls ~/.local/share/claude-profile/
 # Find your profile name, then:
 cp ~/.local/share/claude-profile/YOUR_PROFILE/settings.json ~/.claude/settings.json
-cp ~/.local/share/claude-profile/YOUR_PROFILE/.claude.json ~/.claude.json
+cp ~/.local/share/claude-profile/YOUR_PROFILE/.claude-profile-home.json ~/.claude.json
 # ... etc for other files you need
 ```
+
+An unmigrated store created before format 2 may instead keep the home-level
+file at `YOUR_PROFILE/.claude.json`. Use that legacy path only when
+`.claude-profile-home.json` is absent and you know the store predates format 2.
+In a current store, the root `.claude.json` can be the distinct payload file
+that belongs at `~/.claude/.claude.json`.
 
 **I deleted the profiles directory and need my backup:**
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -20,12 +20,21 @@ If you already detached with `deactivate --keep`, the same command restores the 
 # (e.g. .credentials.json), which a bare * glob would skip
 mkdir -p ~/.claude
 cp -R ~/.local/share/claude-profile/.pre-profiles-backup/. ~/.claude/
-# .claude.json lives in $HOME, not inside ~/.claude/
-mv -f ~/.claude/.claude.json ~/.claude.json 2>/dev/null || true
+# The reserved file represents the home-level ~/.claude.json
+rm -f ~/.claude.json
+if [[ -f ~/.claude/.claude-profile-home.json ]]; then
+  mv -f ~/.claude/.claude-profile-home.json ~/.claude.json
+fi
 rm -f ~/.local/share/claude-profile/.current
 ```
 
 Not every file will exist — errors about missing ones are fine.
+
+An unmigrated backup created before store format 2 may keep the home-level file
+as `.claude.json` instead. Only for that legacy layout, and only when
+`.claude-profile-home.json` is absent, move `~/.claude/.claude.json` to
+`~/.claude.json`. In a current backup it can be a real payload file and must
+remain inside `~/.claude/`.
 
 ## Step 2: Remove the CLI
 

--- a/tests/documentation.bats
+++ b/tests/documentation.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+load test_helper
+
+@test "docs: home-file recovery matches the current store format" {
+  local repo_root stored_name
+  repo_root="$(dirname "$CLAUDE_PROFILE")"
+  stored_name="$(sed -n 's/^CLAUDE_HOME_JSON="\([^"]*\)"/\1/p' "$repo_root/lib/config.sh")"
+
+  [ -n "$stored_name" ]
+  grep -F "YOUR_PROFILE/$stored_name ~/.claude.json" "$repo_root/docs/migration.md"
+  grep -F "$stored_name" "$repo_root/docs/configuration.md" \
+    | grep -F 'stored copy of ~/.claude.json'
+  grep -F "$stored_name" "$repo_root/docs/configuration.md" \
+    | grep -F '**Git-tracked**'
+  [ "$(grep -F "$stored_name" "$repo_root/docs/architecture.md" \
+    | grep -Fc 'stored copy of ~/.claude.json')" -eq 2 ]
+  grep -F '.claude.json                        # template for ~/.claude.json' \
+    "$repo_root/docs/architecture.md"
+  grep -F "$stored_name" "$repo_root/docs/uninstall.md"
+  grep -F 'rm -f ~/.claude.json' "$repo_root/docs/uninstall.md"
+
+  ! grep -F "YOUR_PROFILE/.claude.json ~/.claude.json" "$repo_root/docs/migration.md"
+  ! grep -F 'stored as `.claude.json` inside each profile directory' "$repo_root/docs/architecture.md"
+  ! grep -E '^[[:space:]]*mv -f ~/\.claude/\.claude\.json ~/\.claude\.json' "$repo_root/docs/uninstall.md"
+}


### PR DESCRIPTION
## Summary

- correct the deactivate recovery command to use the format-2 home-config filename
- document the legacy fallback without confusing it with a real payload .claude.json
- synchronize the configuration and architecture layouts while preserving the intentional seed template name
- fix the same unsafe filename assumption in the manual uninstall recovery path
- add a documentation regression test tied to the CLAUDE_HOME_JSON source of truth

Closes #18

## Testing

- bats tests/documentation.bats
- bats tests/ (full pre-push suite passed)