### PR TITLE
Document profile scope against Claude Code's settings precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,31 @@ That's it. Your original config is automatically backed up and can be restored w
 
 ## What gets switched
 
-Each profile snapshots the **entire** `~/.claude/` directory plus `~/.claude.json`. Switching profiles means a completely different Claude "brain" — settings, memory, conversations, plugins, history, everything.
+Each profile snapshots the **entire** `~/.claude/` directory plus `~/.claude.json` — user settings, memory, conversations, agents, skills, plugins, history.
 
 Profiles are stored in `~/.local/share/claude-profile/` (XDG-compliant), separate from `~/.claude/`.
+
+`~/.claude.json` is Claude Code's own file in `$HOME`, outside `~/.claude/`. Alongside MCP server configuration it records which account you are signed in as, per-project state such as trust decisions and MCP server approvals, and the global config keys `/config` writes. `new` seeds it empty, so a fresh profile runs onboarding again and asks you to trust each folder. The login token itself is stored separately: on macOS in the Keychain, which profiles never touch, and on Linux and Windows in `~/.claude/.credentials.json`, which is inside the snapshot — so on those platforms the token swaps with the profile. macOS [falls back to that same file](https://code.claude.com/docs/en/iam#credential-management) whenever the Keychain refuses the write, such as a locked Keychain in an SSH session. Wherever that file exists it belongs to the profile and is versioned with it, so `restore` can bring an earlier login back. The store is created `chmod 700` and the CLI runs under `umask 077`, so every copy stays readable only by you.
+
+### What is not switched
+
+A profile covers your **user-level** configuration. Claude Code also reads per-project files out of the repository you open, and those stay where they are through every switch:
+
+| Lives in the repository | What it carries |
+| --- | --- |
+| `.claude/settings.json` | Settings shared with the team |
+| `.claude/settings.local.json` | Your own settings for that repo — where **Yes, and don't ask again** saves an allow rule |
+| `.mcp.json` | Project-scoped MCP servers |
+| `CLAUDE.md`, `.claude/agents/`, `.claude/skills/` | Project instructions, agents, and skills |
+
+How they combine with the profile, per Claude Code's [settings precedence](https://code.claude.com/docs/en/settings#settings-precedence):
+
+- **Permission rules from every file merge into one set, evaluated `deny` → `ask` → `allow`.** Scope does not break the tie, so a profile's `deny` or `ask` rule still holds in a repo whose `.claude/settings.local.json` allows the same call. What a repo's saved allow rules do reach is everything the profile leaves un-ruled — so write a restrictive profile as explicit `deny`/`ask` entries rather than relying on an empty `allow` list.
+- **Where both files set the same single-value key, the repository's wins.** A project's `permissions.defaultMode` beats the profile's, except `auto` and `bypassPermissions`, which project files cannot set. Not every key is up for grabs: a repository's shared `.claude/settings.json` cannot set the keys the [settings reference](https://code.claude.com/docs/en/settings-reference#all-settings) scopes `User or managed`, `Managed`, or `Global config`, so for those the profile's value stands.
+- **Project-scoped MCP servers outrank user-scoped ones and are not merged**, so a server declared in a repo's `.mcp.json` loads under every profile.
+- **Managed settings sit above all of it.** A `managed-settings.json` file, an MDM policy, or server-managed settings from the claude.ai console are deployed by your organization, live outside `~/.claude/`, and no profile overrides them.
+
+Run `/status` inside Claude Code to list the settings files the running session actually loaded.
 
 ## Commands
 
@@ -130,6 +152,9 @@ delete <name> [-f]      Delete a profile
 deactivate              Restore original state, turn off profiles
 deactivate --keep       Detach from profiles, keep current config
 ```
+
+> [!WARNING]
+> Quit your Claude Code sessions before you switch. Claude Code watches its settings files and reloads `permissions` and `hooks` into a running session, so `use` can replace a live session's guardrails mid-conversation. It also moves that session's transcript and history files out from under it.
 
 ### Deactivating and coming back
 
@@ -238,13 +263,17 @@ See the full [migration guide](docs/migration.md) for details and troubleshootin
 <details>
 <summary><strong>Does switching profiles affect running Claude Code sessions?</strong></summary>
 
-Claude Code reads config at startup. A running session won't pick up profile changes until you restart it.
+Yes — quit them first. Claude Code [watches its settings files and reloads them](https://code.claude.com/docs/en/settings#when-edits-take-effect) without a restart, `permissions` and `hooks` included, so switching from a second terminal replaces a live session's guardrails mid-conversation. `model`, `effortLevel`, and `outputStyle` are read once at session start, so the session ends up running on a mix of both profiles — `/model` and `/effort` move the first two mid-session, and `outputStyle` applies after `/clear` or a restart.
+
+`use` moves rather than copies, so that session's transcript under `projects/`, plus `shell-snapshots/` and `file-history/`, are relocated into the profile it just auto-saved at the same moment.
 </details>
 
 <details>
 <summary><strong>What about MCP servers?</strong></summary>
 
-`~/.claude.json` (which contains MCP server configs) is managed by profiles. Each profile gets its own MCP server setup.
+User-scoped and per-project servers live in `~/.claude.json`, which profiles manage — so each profile gets its own set.
+
+Project-scoped servers are the exception. They are declared in a `.mcp.json` file inside the repository, [outrank user-scoped ones](https://code.claude.com/docs/en/mcp#scope-hierarchy-and-precedence), and load under every profile. Your approval of them is per-project state in `~/.claude.json`, so a fresh profile asks you to approve them again.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -112,31 +112,17 @@ That's it. Your original config is automatically backed up and can be restored w
 
 ## What gets switched
 
-Each profile snapshots the **entire** `~/.claude/` directory plus `~/.claude.json` — user settings, memory, conversations, agents, skills, plugins, history.
+Each profile snapshots the **entire** `~/.claude/` directory plus `~/.claude.json` — user settings, memory, conversations, agents, skills, plugins, history. `new` seeds `~/.claude.json` empty, so a fresh profile runs onboarding again and asks you to trust each folder.
 
 Profiles are stored in `~/.local/share/claude-profile/` (XDG-compliant), separate from `~/.claude/`.
 
-`~/.claude.json` is Claude Code's own file in `$HOME`, outside `~/.claude/`. Alongside MCP server configuration it records which account you are signed in as, per-project state such as trust decisions and MCP server approvals, and the global config keys `/config` writes. `new` seeds it empty, so a fresh profile runs onboarding again and asks you to trust each folder. The login token itself is stored separately: on macOS in the Keychain, which profiles never touch, and on Linux and Windows in `~/.claude/.credentials.json`, which is inside the snapshot — so on those platforms the token swaps with the profile. macOS [falls back to that same file](https://code.claude.com/docs/en/iam#credential-management) whenever the Keychain refuses the write, such as a locked Keychain in an SSH session. Wherever that file exists it belongs to the profile and is versioned with it, so `restore` can bring an earlier login back. The store is created `chmod 700` and the CLI runs under `umask 077`, so every copy stays readable only by you.
-
 ### What is not switched
 
-A profile covers your **user-level** configuration. Claude Code also reads per-project files out of the repository you open, and those stay where they are through every switch:
+That covers your **user-level** configuration. Claude Code also reads per-project files from the repository you open — `.claude/settings.json`, `.claude/settings.local.json` (where **Yes, and don't ask again** saves an allow rule), `.mcp.json`, and project `CLAUDE.md` — plus any managed settings your organization deploys. None of those are switched, and a profile does not override them.
 
-| Lives in the repository | What it carries |
-| --- | --- |
-| `.claude/settings.json` | Settings shared with the team |
-| `.claude/settings.local.json` | Your own settings for that repo — where **Yes, and don't ask again** saves an allow rule |
-| `.mcp.json` | Project-scoped MCP servers |
-| `CLAUDE.md`, `.claude/agents/`, `.claude/skills/` | Project instructions, agents, and skills |
+Permission rules from every file merge into one set, evaluated `deny` → `ask` → `allow`, so a profile's `deny`/`ask` rule holds against a repo's saved allow rules. What those allow rules do reach is anything the profile leaves un-ruled — so write a restrictive profile as explicit `deny`/`ask` entries rather than relying on an empty `allow` list.
 
-How they combine with the profile, per Claude Code's [settings precedence](https://code.claude.com/docs/en/settings#settings-precedence):
-
-- **Permission rules from every file merge into one set, evaluated `deny` → `ask` → `allow`.** Scope does not break the tie, so a profile's `deny` or `ask` rule still holds in a repo whose `.claude/settings.local.json` allows the same call. What a repo's saved allow rules do reach is everything the profile leaves un-ruled — so write a restrictive profile as explicit `deny`/`ask` entries rather than relying on an empty `allow` list.
-- **Where both files set the same single-value key, the repository's wins.** A project's `permissions.defaultMode` beats the profile's, except `auto` and `bypassPermissions`, which project files cannot set. Not every key is up for grabs: a repository's shared `.claude/settings.json` cannot set the keys the [settings reference](https://code.claude.com/docs/en/settings-reference#all-settings) scopes `User or managed`, `Managed`, or `Global config`, so for those the profile's value stands.
-- **Project-scoped MCP servers outrank user-scoped ones and are not merged**, so a server declared in a repo's `.mcp.json` loads under every profile.
-- **Managed settings sit above all of it.** A `managed-settings.json` file, an MDM policy, or server-managed settings from the claude.ai console are deployed by your organization, live outside `~/.claude/`, and no profile overrides them.
-
-Run `/status` inside Claude Code to list the settings files the running session actually loaded.
+[What a profile covers](docs/configuration.md#what-a-profile-covers) has the full precedence rules, what `~/.claude.json` carries, and where your login is stored.
 
 ## Commands
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,8 +97,11 @@ Profiles are stored in an XDG-compliant location, separate from `~/.claude/`:
 
 Priority: `CLAUDE_PROFILE_HOME` > `XDG_DATA_HOME/claude-profile` > `$HOME/.local/share/claude-profile`
 
-The home-level `~/.claude.json` file (including MCP server config) lives in
-`$HOME`, not inside `~/.claude/`. It is stored as
+The home-level `~/.claude.json` file lives in `$HOME`, not inside `~/.claude/`.
+Alongside MCP server configuration it holds the signed-in account record,
+per-project state such as trust decisions and MCP server approvals, and the
+global config keys `/config` writes — so seeding it as `{}` in a new profile
+resets onboarding and folder trust, not just MCP. It is stored as
 `.claude-profile-home.json` inside each profile directory and copied to/from
 `$HOME/.claude.json` on switch. This reserved name is disjoint from a live
 payload file literally named `~/.claude/.claude.json`, which is stored at the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,12 +32,64 @@ Think of it like git branches. Your original `~/.claude/` state is the **main br
 
 Profiles are stored in `~/.local/share/claude-profile/` (XDG-compliant), separate from `~/.claude/`. Each profile snapshots the **entire** `~/.claude/` directory plus `~/.claude.json`.
 
-That is your user-level configuration. Claude Code also reads per-project files from the repository you open — `.claude/settings.json`, `.claude/settings.local.json`, `.mcp.json`, `CLAUDE.md` — plus any managed settings your organization deploys, and none of those are switched. See [What is not switched](../README.md#what-is-not-switched) for how they combine with the profile.
-
 Inside a stored profile, the home-level `~/.claude.json` is named
 `.claude-profile-home.json`. The reserved name keeps it separate from a payload
 file literally named `~/.claude/.claude.json`, which remains `.claude.json` at
 the profile root.
+
+## What a profile covers
+
+A profile holds your **user-level** configuration. Claude Code reads four other
+places that no profile contains or swaps.
+
+| Lives in the repository | What it carries |
+| --- | --- |
+| `.claude/settings.json` | Settings shared with the team |
+| `.claude/settings.local.json` | Your own settings for that repo — where **Yes, and don't ask again** saves an allow rule |
+| `.mcp.json` | Project-scoped MCP servers |
+| `CLAUDE.md`, `.claude/agents/`, `.claude/skills/` | Project instructions, agents, and skills |
+
+Managed settings are the fifth: a `managed-settings.json` file, an MDM policy,
+or server-managed settings from the claude.ai console, deployed by your
+organization and outranking everything below.
+
+How they combine with the profile, per Claude Code's
+[settings precedence](https://code.claude.com/docs/en/settings#settings-precedence):
+
+- **Permission rules from every file merge into one set, evaluated `deny` →
+  `ask` → `allow`.** Scope does not break the tie, so a profile's `deny` or
+  `ask` rule still holds in a repo whose `.claude/settings.local.json` allows
+  the same call. What a repo's saved allow rules do reach is everything the
+  profile leaves un-ruled — so write a restrictive profile as explicit
+  `deny`/`ask` entries rather than relying on an empty `allow` list.
+- **Where both files set the same single-value key, the repository's wins.** A
+  project's `permissions.defaultMode` beats the profile's, except `auto` and
+  `bypassPermissions`, which project files cannot set. Not every key is up for
+  grabs: a repository's shared `.claude/settings.json` cannot set the keys the
+  [settings reference](https://code.claude.com/docs/en/settings-reference#all-settings)
+  scopes `User or managed`, `Managed`, or `Global config`, so for those the
+  profile's value stands.
+- **Project-scoped MCP servers outrank user-scoped ones and are not merged**, so
+  a server declared in a repo's `.mcp.json` loads under every profile.
+
+Run `/status` inside Claude Code to list the settings files the running session
+actually loaded.
+
+### What `~/.claude.json` carries
+
+`~/.claude.json` is Claude Code's own file in `$HOME`, outside `~/.claude/`.
+Alongside MCP server configuration it records which account you are signed in
+as, per-project state such as trust decisions and MCP server approvals, and the
+global config keys `/config` writes. `new` seeds it empty, so a fresh profile
+runs onboarding again and asks you to trust each folder.
+
+The login token itself is stored separately: on macOS in the Keychain, which
+profiles never touch, and on Linux and Windows in `~/.claude/.credentials.json`,
+which is inside the snapshot — so on those platforms the token swaps with the
+profile. macOS
+[falls back to that same file](https://code.claude.com/docs/en/iam#credential-management)
+whenever the Keychain refuses the write, such as a locked Keychain in an SSH
+session.
 
 ## Seed templates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,8 @@ Think of it like git branches. Your original `~/.claude/` state is the **main br
 
 Profiles are stored in `~/.local/share/claude-profile/` (XDG-compliant), separate from `~/.claude/`. Each profile snapshots the **entire** `~/.claude/` directory plus `~/.claude.json`.
 
+That is your user-level configuration. Claude Code also reads per-project files from the repository you open — `.claude/settings.json`, `.claude/settings.local.json`, `.mcp.json`, `CLAUDE.md` — plus any managed settings your organization deploys, and none of those are switched. See [What is not switched](../README.md#what-is-not-switched) for how they combine with the profile.
+
 Inside a stored profile, the home-level `~/.claude.json` is named
 `.claude-profile-home.json`. The reserved name keeps it separate from a payload
 file literally named `~/.claude/.claude.json`, which remains `.claude.json` at
@@ -67,11 +69,15 @@ disposable/session data while all files are still copied between profiles:
 
 This means `history`, `diff`, and `restore` cover persistent memory as well as
 configuration, without filling history with transcripts. Memory can contain
-personal preferences and project learnings; because it is versioned, deleting
-it from the live profile does not remove older copies from that profile's Git
-history. These repositories and Git objects stay local and are not uploaded by
-claude-profile, but they are plaintext and protected only by filesystem
-permissions.
+personal preferences and project learnings, and the stored `~/.claude.json`
+carries the signed-in account record and MCP server definitions; because both
+are versioned, deleting them from the live profile does not remove older copies
+from that profile's Git history. On Linux and Windows — and on macOS whenever
+the Keychain write is rejected — `.credentials.json` is versioned too, so
+`restore` can bring an earlier login back. These repositories and Git objects
+stay local and are not uploaded by claude-profile; they are plaintext, protected
+only by filesystem permissions — the store is created `chmod 700` and every
+command runs under `umask 077`, so the copies stay readable just by you.
 
 Existing profiles receive the managed rules automatically. Their first
 subsequent save establishes the earliest recoverable memory baseline. Restoring
@@ -115,11 +121,13 @@ If you have a custom statusline, `install` won't overwrite it. You can reference
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CLAUDE_CODE_HOME` | `~/.claude` | Claude Code config directory |
+| `CLAUDE_CODE_HOME` | `~/.claude` | Live Claude Code directory that `claude-profile` snapshots and swaps |
 | `CLAUDE_PROFILE_HOME` | *(see below)* | Override profiles storage location |
 | `XDG_DATA_HOME` | `~/.local/share` | XDG data directory (profiles stored in `$XDG_DATA_HOME/claude-profile`) |
 | `CLAUDE_PROFILE_INSTALL_DIR` | `~/.local/bin` | Install location for the binary |
 | `CLAUDE_PROFILE_COMPLETIONS_DIR` | *(auto-detect)* | Custom completions directory |
+
+`CLAUDE_CODE_HOME` belongs to `claude-profile`; Claude Code does not read it. Claude Code relocates its own home-directory files with [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars), which `claude-profile` does not read — so if you set that, point `CLAUDE_CODE_HOME` at the same directory or profiles will manage one Claude Code no longer reads.
 
 ### Storage location resolution
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -31,8 +31,8 @@ After this, your `~/.claude/` will look exactly as if you'd configured it manual
 After running it:
 - `~/.claude/settings.json` — your current profile's settings (unchanged)
 - `~/.claude/CLAUDE.md` — your current profile's instructions (unchanged)
-- `~/.claude/projects/` — your current profile's memory (unchanged)
-- `~/.claude.json` — your current profile's MCP servers (unchanged)
+- `~/.claude/projects/` — your current profile's session history and auto memory (unchanged)
+- `~/.claude.json` — your current profile's MCP servers, signed-in account, per-project trust decisions, and `/config` keys (unchanged)
 - `~/.local/share/claude-profile/` — all saved profiles (can be deleted or kept for reference)
 
 ## If you change your mind


### PR DESCRIPTION
Documents what a profile covers and what Claude Code reads from outside it. Closes #17.

The README keeps what a reader needs at a glance; `docs/configuration.md` carries the detail.

## README

**What gets switched** names the snapshot contents and notes that `new` seeds `~/.claude.json` empty, so a fresh profile runs onboarding again and asks you to trust each folder.

**What is not switched** lists the per-project files that stay in the repository — `.claude/settings.json`, `.claude/settings.local.json`, `.mcp.json`, project `CLAUDE.md` — plus managed settings, and states the one consequence worth knowing up front: permission rules from every file merge and evaluate `deny` → `ask` → `allow`, so a profile's `deny`/`ask` rule holds against a repo's saved allow rules, while those allow rules still reach anything the profile leaves un-ruled. It links to the full rules.

A warning beside the commands table and a rewritten FAQ entry cover switching while a session runs: Claude Code reloads `permissions` and `hooks` without a restart, `model`, `effortLevel`, and `outputStyle` are read at session start, and `use` relocates a live session's transcript, `shell-snapshots/`, and `file-history/`. The MCP FAQ distinguishes user and per-project servers in `~/.claude.json` from project-scoped `.mcp.json` servers.

Net +15 lines.

## docs/configuration.md

A new **What a profile covers** section holds the table of repository-scoped files, the full precedence rules (list merging and `deny` → `ask` → `allow`; single-value keys, including those a shared project file cannot set; project-scoped MCP servers outranking user scope; managed settings above all of it), and the `/status` tip.

**What `~/.claude.json` carries** covers the signed-in account record, per-project trust decisions, and the global config keys `/config` writes, alongside MCP configuration — plus where the login token is stored: the macOS Keychain, or `~/.claude/.credentials.json` on Linux and Windows and as the macOS fallback when the Keychain refuses the write.

## docs/architecture.md, docs/migration.md

`~/.claude.json` described consistently at the remaining sites; `~/.claude/projects/` named as session history and auto memory.

`CLAUDE_CODE_HOME` is documented as claude-profile's own variable — Claude Code relocates its home-directory files with `CLAUDE_CONFIG_DIR`, which claude-profile does not read, so setting one without the other leaves profiles managing a directory Claude Code no longer reads.

## Where this diverges from the issue

#17 suggests documenting that a repository's saved "Yes, and don't ask again" allow rules "win over the profile's `permissions`". These docs state it differently, because permission rules merge across scopes and evaluate `deny` → `ask` → `allow` with scope not breaking the tie ([permissions](https://code.claude.com/docs/en/permissions#settings-precedence), [lists merge instead of overriding](https://code.claude.com/docs/en/settings#lists-merge-instead-of-overriding)):

> if user settings allow a permission and project settings deny it, the deny rule blocks it. The reverse is also true: a user-level deny blocks a project-level allow, because deny rules from any scope are evaluated before allow rules.

A profile's `deny`/`ask` rule holds against a repository's allow rules. What those allow rules do reach is anything the profile leaves un-ruled — hence the advice to write a restrictive profile as explicit `deny`/`ask` entries rather than relying on an empty `allow` list.

## Verification

Every behavioral claim is cited to code.claude.com. All 5 internal anchor links across README and `docs/` resolve. `bats tests/` — 373 passing via the pre-push hook.
